### PR TITLE
fix(favicon): logo phenix dans l'onglet et sur Google

### DIFF
--- a/pokecard/index.html
+++ b/pokecard/index.html
@@ -2,7 +2,6 @@
 <html lang="fr" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />

--- a/pokecard/public/favicon.svg
+++ b/pokecard/public/favicon.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <rect width="64" height="64" rx="12" fill="#0a0a0a"/>
-  <text x="50%" y="50%" dy="0.35em" text-anchor="middle"
-        font-family="Georgia, 'Times New Roman', serif" font-size="38" font-weight="700"
-        fill="#d4af37">B</text>
-</svg>

--- a/pokecard/public/site.webmanifest
+++ b/pokecard/public/site.webmanifest
@@ -10,12 +10,6 @@
   "lang": "fr",
   "icons": [
     {
-      "src": "/favicon.svg",
-      "sizes": "any",
-      "type": "image/svg+xml",
-      "purpose": "any"
-    },
-    {
       "src": "/favicon.png",
       "sizes": "512x512",
       "type": "image/png",


### PR DESCRIPTION
## Problème
Le `favicon.svg` était encore un placeholder — un **« B » doré sur fond noir** — déclaré en premier avec `type="image/svg+xml"`, donc affiché en priorité par les navigateurs et Google, masquant le logo phénix de la navbar.

Le phénix était pourtant déjà présent dans `favicon.png` (512×512) et `apple-touch-icon.png`.

## Changements
- `pokecard/index.html` — retrait du `<link rel="icon" type="image/svg+xml" href="/favicon.svg">`
- `pokecard/public/site.webmanifest` — retrait de l'entrée icône SVG
- Suppression de `pokecard/public/favicon.svg` (le « B »)

## Résultat
Le phénix sert désormais d'icône partout : **onglet navigateur, résultats Google et PWA**.

## Note
L'`og:image` (aperçu de partage social) n'a pas été modifié — il pointe toujours vers la carte Dracaufeu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
