### PR TITLE
chore(seo): description meta orientee boutique TCG passionnee

### DIFF
--- a/pokecard/index.html
+++ b/pokecard/index.html
@@ -13,7 +13,7 @@
          surchargées par page via le composant <Seo /> côté React) -->
     <meta
       name="description"
-      content="BoulevardTCG — boutique de cartes à collectionner : produits scellés Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana. Authenticité garantie, paiement sécurisé."
+      content="BoulevardTCG, votre boutique TCG par des passionnés : produits scellés et cartes à collectionner Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana."
     />
     <link rel="canonical" href="https://boulevardtcg.com/" />
     <meta property="og:site_name" content="BoulevardTCG" />
@@ -22,7 +22,7 @@
     <meta property="og:title" content="BoulevardTCG — Le Boulevard Prestige du TCG" />
     <meta
       property="og:description"
-      content="Produits scellés Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana. Authenticité garantie, paiement sécurisé."
+      content="Votre boutique TCG par des passionnés : produits scellés et cartes à collectionner Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana."
     />
     <meta property="og:url" content="https://boulevardtcg.com/" />
     <meta property="og:image" content="https://boulevardtcg.com/carte_accueil/dracaufeu.png" />

--- a/pokecard/src/Home.tsx
+++ b/pokecard/src/Home.tsx
@@ -40,7 +40,7 @@ export function Home() {
     <>
       <Seo
         title="Cartes à collectionner & produits scellés"
-        description="BoulevardTCG : boutique premium de cartes à collectionner. Produits scellés Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana. Authenticité garantie, paiement sécurisé, livraison soignée."
+        description="BoulevardTCG, votre boutique TCG par des passionnés : produits scellés et cartes à collectionner Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana."
         canonical="/"
         jsonLd={homeJsonLd}
       />

--- a/pokecard/src/lib/site.ts
+++ b/pokecard/src/lib/site.ts
@@ -9,7 +9,7 @@ export const SITE_URL = (import.meta.env.VITE_SITE_URL ?? 'https://boulevardtcg.
 export const SITE_NAME = 'BoulevardTCG';
 
 export const SITE_DESCRIPTION =
-  'BoulevardTCG — boutique de cartes à collectionner : produits scellés Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana. Authenticité garantie, paiement sécurisé, livraison soignée.';
+  'BoulevardTCG, votre boutique TCG par des passionnés : produits scellés et cartes à collectionner Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana.';
 
 // Image de partage par défaut (Open Graph / Twitter). 1200x630 recommandé.
 export const SITE_OG_IMAGE = '/carte_accueil/dracaufeu.png';


### PR DESCRIPTION
## Objectif
Améliorer la description qui apparaît sur Google et au partage, avec un ton « boutique passionnée » sobre et le mot-clé **TCG** comme terme à part entière.

## Changements
Même phrase appliquée aux 3 endroits qui doivent rester cohérents :
- `pokecard/index.html` — meta description + og:description (fallback crawlers)
- `pokecard/src/lib/site.ts` — `SITE_DESCRIPTION` (défaut de toutes les pages)
- `pokecard/src/Home.tsx` — description de la home

> BoulevardTCG, votre boutique TCG par des passionnés : produits scellés et cartes à collectionner Pokémon, One Piece, Magic, Yu-Gi-Oh! et Lorcana.

Mots-clés couverts : TCG, cartes à collectionner, produits scellés + les 5 univers. Retrait des arguments marketing génériques (« authenticité garantie ») jugés peu crédibles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
