### PR TITLE
feat(seo,rgpd): sitemap produits, JSON-LD enrichi, minimisation emails admin

### DIFF
--- a/pokecard/package.json
+++ b/pokecard/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/generate-sitemap.mjs",
     "build": "tsc --noUnusedLocals false --noUnusedParameters false && vite build",
     "sitemap": "node scripts/generate-sitemap.mjs",
     "optimize:images": "node scripts/optimize-images.mjs",

--- a/pokecard/scripts/generate-sitemap.mjs
+++ b/pokecard/scripts/generate-sitemap.mjs
@@ -47,22 +47,39 @@ function urlEntry({ path, changefreq, priority, lastmod }) {
 
 async function fetchProductRoutes() {
   if (!API_URL) return [];
+  const base = API_URL.replace(/\/$/, '');
+  // L'API plafonne `limit` à 48 → on pagine jusqu'à épuisement.
+  const limit = 48;
+  const collected = [];
+
+  const pushProduct = (p) => {
+    if (!p?.slug) return;
+    collected.push({
+      path: `/produit/${p.slug}`,
+      changefreq: 'weekly',
+      priority: '0.8',
+      lastmod: p.updatedAt ? new Date(p.updatedAt).toISOString().slice(0, 10) : undefined,
+    });
+  };
+
   try {
-    const res = await fetch(`${API_URL.replace(/\/$/, '')}/products?limit=1000`);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const json = await res.json();
-    const products = Array.isArray(json) ? json : (json.data ?? []);
-    return products
-      .filter((p) => p?.slug)
-      .map((p) => ({
-        path: `/produit/${p.slug}`,
-        changefreq: 'weekly',
-        priority: '0.8',
-        lastmod: p.updatedAt ? new Date(p.updatedAt).toISOString().slice(0, 10) : undefined,
-      }));
+    let page = 1;
+    let pages = 1;
+    do {
+      const res = await fetch(`${base}/products?limit=${limit}&page=${page}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      // L'API renvoie { products, pagination }. Fallbacks au cas où.
+      const products = json.products ?? json.data ?? (Array.isArray(json) ? json : []);
+      products.forEach(pushProduct);
+      pages = json.pagination?.pages ?? 1;
+      page += 1;
+    } while (page <= pages);
+    return collected;
   } catch (err) {
     console.warn(`[sitemap] Produits ignorés (API injoignable) : ${err.message}`);
-    return [];
+    // On garde ce qui a déjà été collecté avant l'erreur éventuelle.
+    return collected;
   }
 }
 

--- a/pokecard/scripts/generate-sitemap.mjs
+++ b/pokecard/scripts/generate-sitemap.mjs
@@ -6,15 +6,26 @@
  *   SITE_URL=https://boulevardtcg.com API_URL=https://api.boulevardtcg.com/api \
  *     node scripts/generate-sitemap.mjs
  *
- * Sans API_URL ou si l'API est injoignable, seules les pages statiques sont écrites
- * (le build ne casse pas).
+ * En l'absence de SITE_URL / API_URL, le script réutilise VITE_SITE_URL /
+ * VITE_API_URL (déjà définis dans le build front, ex. sur Vercel) — donc rien
+ * à configurer en plus en pratique.
+ *
+ * Sans aucune URL d'API ou si l'API est injoignable, seules les pages statiques
+ * sont écrites (le build ne casse pas).
  */
 import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-const SITE_URL = (process.env.SITE_URL ?? 'https://boulevardtcg.com').replace(/\/$/, '');
-const API_URL = process.env.API_URL ?? '';
+// Réutilise les variables déjà présentes dans l'environnement de build du
+// frontend (Vercel : VITE_API_URL est déjà défini pour que le site appelle
+// l'API). On accepte aussi SITE_URL / API_URL si on veut surcharger.
+const SITE_URL = (
+  process.env.SITE_URL ??
+  process.env.VITE_SITE_URL ??
+  'https://boulevardtcg.com'
+).replace(/\/$/, '');
+const API_URL = process.env.API_URL ?? process.env.VITE_API_URL ?? '';
 
 const STATIC_ROUTES = [
   { path: '/', changefreq: 'daily', priority: '1.0' },

--- a/pokecard/src/ProductDetail.tsx
+++ b/pokecard/src/ProductDetail.tsx
@@ -359,6 +359,11 @@ export function ProductDetail() {
     product.minPriceCents != null ? (product.minPriceCents / 100).toFixed(2) : undefined;
   const inStock = !product.outOfStock && product.variants.some((v) => v.stock > 0);
   const ratingStats = reviewsData?.stats;
+  // Validité du prix annoncée à Google (~1 an) pour éviter l'avertissement
+  // "priceValidUntil manquant" dans les rich results.
+  const priceValidUntil = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0];
 
   const productJsonLd = {
     '@context': 'https://schema.org',
@@ -377,6 +382,8 @@ export function ProductDetail() {
             price: priceEuros,
             priceCurrency: 'EUR',
             availability: inStock ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
+            itemCondition: 'https://schema.org/NewCondition',
+            priceValidUntil,
             url: absoluteUrl(`/produit/${product.slug}`),
           },
         }

--- a/pokecard/src/pages/admin/AdminUsersPage.module.css
+++ b/pokecard/src/pages/admin/AdminUsersPage.module.css
@@ -180,6 +180,26 @@
   color: var(--color-text-secondary, #a1a1a6);
 }
 
+/* Email masqué par défaut (RGPD : minimisation) — révélé au clic */
+.emailButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1, 0.25rem);
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+  color: var(--color-text-secondary, #a1a1a6);
+  transition: color 0.15s ease;
+}
+
+.emailButton:hover,
+.emailButton:focus-visible {
+  color: var(--color-text-primary, #f5f5f7);
+  text-decoration: underline;
+}
+
 .orderCount {
   display: inline-block;
   padding: var(--space-1, 0.25rem) var(--space-2, 0.5rem);

--- a/pokecard/src/pages/admin/AdminUsersPage.tsx
+++ b/pokecard/src/pages/admin/AdminUsersPage.tsx
@@ -40,6 +40,17 @@ const UsersIcon = () => (
   </svg>
 );
 
+/**
+ * Masque partiellement un email (RGPD : minimisation de l'affichage).
+ * "jean.dupont@gmail.com" -> "je***@gmail.com"
+ */
+function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return '***';
+  const visible = local.slice(0, 2);
+  return `${visible}${'*'.repeat(Math.max(3, local.length - 2))}@${domain}`;
+}
+
 interface User {
   id: string;
   email: string;
@@ -56,6 +67,15 @@ export function AdminUsersPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
+  const [revealedEmails, setRevealedEmails] = useState<Set<string>>(new Set());
+
+  const toggleEmail = (id: string) =>
+    setRevealedEmails((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   const { user, token, isLoading: authLoading } = useAuth();
   const navigate = useNavigate();
 
@@ -167,7 +187,18 @@ export function AdminUsersPage() {
                     </div>
                   </td>
                   <td>
-                    <span className={styles.email}>{u.email}</span>
+                    <button
+                      type="button"
+                      className={styles.emailButton}
+                      onClick={() => toggleEmail(u.id)}
+                      title={
+                        revealedEmails.has(u.id)
+                          ? "Masquer l'email"
+                          : "Cliquer pour révéler l'email"
+                      }
+                    >
+                      {revealedEmails.has(u.id) ? u.email : maskEmail(u.email)}
+                    </button>
                   </td>
                   <td>
                     <span className={styles.orderCount}>{u._count.orders}</span>

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -13,7 +13,7 @@ import {
   sendOrderConfirmationEmail,
 } from '../services/email.js';
 import { buildTrackingUrl, generateOrderTrackingToken } from '../utils/tracking.js';
-import { audit } from '../utils/audit.js';
+import { audit, auditLog } from '../utils/audit.js';
 
 const router = Router();
 
@@ -1163,6 +1163,14 @@ router.get('/users', async (req: Request, res: Response) => {
       prisma.user.count({ where }),
     ]);
 
+    // RGPD : tracer la consultation admin de données personnelles (emails clients)
+    auditLog(req, 'USER_DATA_ACCESS', 'user', 'list', {
+      action: 'ADMIN_LIST_USERS',
+      count: users.length,
+      search: search ? String(search) : undefined,
+      role: role ? String(role) : undefined,
+    });
+
     res.json({
       users,
       pagination: {
@@ -1212,6 +1220,9 @@ router.get('/users/:userId', async (req: Request, res: Response) => {
         code: 'USER_NOT_FOUND',
       });
     }
+
+    // RGPD : tracer la consultation admin de la fiche détaillée d'un utilisateur
+    auditLog(req, 'USER_DATA_ACCESS', 'user', userId, { action: 'ADMIN_VIEW_USER' });
 
     res.json({ user });
   } catch {

--- a/server/src/utils/audit.ts
+++ b/server/src/utils/audit.ts
@@ -13,6 +13,7 @@ export type AuditAction =
   | 'ORDER_DELIVER'
   | 'USER_UPDATE'
   | 'USER_ROLE_CHANGE'
+  | 'USER_DATA_ACCESS'
   | 'PROMO_CREATE'
   | 'PROMO_UPDATE'
   | 'PROMO_DELETE'


### PR DESCRIPTION
## Contexte
Suite à une analyse SEO + RGPD du site. Plusieurs éléments étaient déjà bien faits (JSON-LD Organization/Product/Breadcrumb, routes RGPD utilisateur, route admin protégée). Cette PR comble les manques réels.

## SEO
- **Sitemap produits** : `scripts/generate-sitemap.mjs` était cassé pour ce backend — il lisait `json.data` au lieu de `json.products` (→ 0 produit récupéré) et demandait `limit=1000` ignoré (l'API plafonne à 48). Corrigé : lecture de la bonne clé + **pagination**. Les fiches `/produit/:slug` entrent désormais dans le sitemap avec leur `lastmod`.
- **Génération au build** : hook `prebuild` → le sitemap est régénéré automatiquement avant chaque build. Fallback pages statiques si l'API est injoignable (le build ne casse jamais).
- **JSON-LD produit enrichi** (`ProductDetail.tsx`) : l'`Offer` inclut maintenant `itemCondition: NewCondition` + `priceValidUntil` (~1 an) pour éviter les avertissements Google Rich Results.

## RGPD
- **Audit en lecture** : nouvelle action `USER_DATA_ACCESS`, tracée sur `GET /admin/users` (liste) et `/admin/users/:id` (fiche). On sait quel admin consulte les données personnelles.
- **Minimisation de l'affichage** : dans `AdminUsersPage`, les emails sont masqués par défaut (`je***@domaine`) et révélés au clic.

## Déploiement ⚠️
Pour que les produits apparaissent dans le sitemap, définir `SITE_URL` et `API_URL` au build (sinon : pages statiques seules).

## Validation
- Backend typecheck OK, tests d'audit 22/22 ✅
- Fichiers front modifiés : lint + typecheck clean

## Hors scope (volontaire)
- Image OG 1200×630 (reportée à la demande)
- Pré-rendu / SSR pour les meta par page (chantier architectural séparé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
