### PR TITLE
perf(front): allege le bundle initial (473->384 KB de JS precharge)

### DIFF
--- a/pokecard/package-lock.json
+++ b/pokecard/package-lock.json
@@ -9,10 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@paper-design/shaders-react": "^0.0.69",
-        "@react-three/drei": "^10.7.3",
-        "@react-three/fiber": "^9.3.0",
         "@stripe/stripe-js": "^2.4.0",
-        "@types/three": "^0.179.0",
         "bcryptjs": "^3.0.2",
         "express-validator": "^7.2.1",
         "framer-motion": "^12.19.2",
@@ -20,8 +17,7 @@
         "lucide-react": "^0.556.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2",
-        "three": "^0.179.1"
+        "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -277,15 +273,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -333,12 +320,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@dimforge/rapier3d-compat": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
-      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
-      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
@@ -1539,24 +1520,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mediapipe/tasks-vision": {
-      "version": "0.10.17",
-      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
-      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@monogrid/gainmap-js": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
-      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
-      "license": "MIT",
-      "dependencies": {
-        "promise-worker-transferable": "^1.0.4"
-      },
-      "peerDependencies": {
-        "three": ">= 0.159.0"
-      }
-    },
     "node_modules/@paper-design/shaders": {
       "version": "0.0.69",
       "resolved": "https://registry.npmjs.org/@paper-design/shaders/-/shaders-0.0.69.tgz",
@@ -1577,96 +1540,6 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@react-three/drei": {
-      "version": "10.7.7",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
-      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mediapipe/tasks-vision": "0.10.17",
-        "@monogrid/gainmap-js": "^3.0.6",
-        "@use-gesture/react": "^10.3.1",
-        "camera-controls": "^3.1.0",
-        "cross-env": "^7.0.3",
-        "detect-gpu": "^5.0.56",
-        "glsl-noise": "^0.0.0",
-        "hls.js": "^1.5.17",
-        "maath": "^0.10.8",
-        "meshline": "^3.3.1",
-        "stats-gl": "^2.2.8",
-        "stats.js": "^0.17.0",
-        "suspend-react": "^0.1.3",
-        "three-mesh-bvh": "^0.8.3",
-        "three-stdlib": "^2.35.6",
-        "troika-three-text": "^0.52.4",
-        "tunnel-rat": "^0.1.2",
-        "use-sync-external-store": "^1.4.0",
-        "utility-types": "^3.11.0",
-        "zustand": "^5.0.1"
-      },
-      "peerDependencies": {
-        "@react-three/fiber": "^9.0.0",
-        "react": "^19",
-        "react-dom": "^19",
-        "three": ">=0.159"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@react-three/fiber": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.4.2.tgz",
-      "integrity": "sha512-H4B4+FDNHpvIb4FmphH4ubxOfX5bxmfOw0+3pkQwR9u9wFiyMS7wUDkNn0m4RqQuiLWeia9jfN1eBvtyAVGEog==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.17.8",
-        "@types/react-reconciler": "^0.32.0",
-        "@types/webxr": "*",
-        "base64-js": "^1.5.1",
-        "buffer": "^6.0.3",
-        "its-fine": "^2.0.0",
-        "react-reconciler": "^0.31.0",
-        "react-use-measure": "^2.1.7",
-        "scheduler": "^0.25.0",
-        "suspend-react": "^0.1.3",
-        "use-sync-external-store": "^1.4.0",
-        "zustand": "^5.0.3"
-      },
-      "peerDependencies": {
-        "expo": ">=43.0",
-        "expo-asset": ">=8.4",
-        "expo-file-system": ">=11.0",
-        "expo-gl": ">=11.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "react-native": ">=0.78",
-        "three": ">=0.156"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        },
-        "expo-asset": {
-          "optional": true
-        },
-        "expo-file-system": {
-          "optional": true
-        },
-        "expo-gl": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
           "optional": true
         }
       }
@@ -1992,12 +1865,6 @@
       "integrity": "sha512-WFkQx1mbs2b5+7looI9IV1BLa3bIApuN3ehp9FP58xGg7KL9hCHDECgW3BwO9l9L+xBPVAD7Yjn1EhGe6EDTeA==",
       "license": "MIT"
     },
-    "node_modules/@tweenjs/tween.js": {
-      "version": "23.1.3",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
-      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
-      "license": "MIT"
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2043,12 +1910,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/draco3d": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
-      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2063,16 +1924,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.3",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2087,42 +1943,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/react-reconciler": {
-      "version": "0.32.3",
-      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.3.tgz",
-      "integrity": "sha512-cMi5ZrLG7UtbL7LTK6hq9w/EZIRk4Mf1Z5qHoI+qBh7/WkYkFXQ7gOto2yfUvPzF5ERMAhaXS5eTQ2SAnHjLzA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/stats.js": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
-      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/three": {
-      "version": "0.179.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.179.0.tgz",
-      "integrity": "sha512-VgbFG2Pgsm84BqdegZzr7w2aKbQxmgzIu4Dy7/75ygiD/0P68LKmp5ie08KMPNqGTQwIge8s6D1guZf1RnZE0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@dimforge/rapier3d-compat": "~0.12.0",
-        "@tweenjs/tween.js": "~23.1.3",
-        "@types/stats.js": "*",
-        "@types/webxr": "*",
-        "@webgpu/types": "*",
-        "fflate": "~0.8.2",
-        "meshoptimizer": "~0.22.0"
-      }
-    },
-    "node_modules/@types/webxr": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
-      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.50.1",
@@ -2393,24 +2213,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@use-gesture/core": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
-      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
-      "license": "MIT"
-    },
-    "node_modules/@use-gesture/react": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
-      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@use-gesture/core": "10.3.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0"
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2431,12 +2233,6 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.68",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.68.tgz",
-      "integrity": "sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2508,26 +2304,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -2545,15 +2321,6 @@
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
-      }
-    },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "license": "MIT",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2601,30 +2368,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -2639,19 +2382,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camera-controls": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
-      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.0.0",
-        "npm": ">=10.5.1"
-      },
-      "peerDependencies": {
-        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2739,28 +2469,11 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2775,6 +2488,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2802,15 +2516,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/detect-gpu": {
-      "version": "5.0.70",
-      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
-      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
-      "license": "MIT",
-      "dependencies": {
-        "webgl-constants": "^1.1.1"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2820,12 +2525,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/draco3d": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
-      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3150,12 +2849,6 @@
         }
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "license": "MIT"
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3285,12 +2978,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/glsl-noise": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
-      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
-      "license": "MIT"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3301,32 +2988,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hls.js": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
-      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3336,12 +2997,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -3393,38 +3048,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/its-fine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
-      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react-reconciler": "^0.28.9"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
-      }
-    },
-    "node_modules/its-fine/node_modules/@types/react-reconciler": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
-      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
-      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3572,15 +3201,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3670,31 +3290,6 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/maath": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
-      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/three": ">=0.134.0",
-        "three": ">=0.134.0"
-      }
-    },
-    "node_modules/meshline": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
-      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "three": ">=0.137"
-      }
-    },
-    "node_modules/meshoptimizer": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
-      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3840,6 +3435,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3894,12 +3490,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-      "license": "ISC"
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3924,16 +3514,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/promise-worker-transferable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
-      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-promise": "^2.1.0",
-        "lie": "^3.0.2"
       }
     },
     "node_modules/punycode": {
@@ -3972,21 +3552,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
-    },
-    "node_modules/react-reconciler": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
-      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.25.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4034,30 +3599,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-use-measure": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
-      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.13",
-        "react-dom": ">=16.13"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -4130,12 +3671,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4216,6 +3751,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4228,6 +3764,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4242,32 +3779,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/stats-gl": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
-      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/three": "*",
-        "three": "^0.170.0"
-      },
-      "peerDependencies": {
-        "@types/three": "*",
-        "three": "*"
-      }
-    },
-    "node_modules/stats-gl/node_modules/three": {
-      "version": "0.170.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
-      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
-      "license": "MIT"
-    },
-    "node_modules/stats.js": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
-      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
-      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -4295,53 +3806,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/suspend-react": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
-      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=17.0"
-      }
-    },
-    "node_modules/three": {
-      "version": "0.179.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
-      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
-      "license": "MIT"
-    },
-    "node_modules/three-mesh-bvh": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
-      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "three": ">= 0.159.0"
-      }
-    },
-    "node_modules/three-stdlib": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
-      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/draco3d": "^1.4.0",
-        "@types/offscreencanvas": "^2019.6.4",
-        "@types/webxr": "^0.5.2",
-        "draco3d": "^1.4.1",
-        "fflate": "^0.6.9",
-        "potpack": "^1.0.1"
-      },
-      "peerDependencies": {
-        "three": ">=0.128.0"
-      }
-    },
-    "node_modules/three-stdlib/node_modules/fflate": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
-      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4358,36 +3822,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/troika-three-text": {
-      "version": "0.52.4",
-      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
-      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
-      "license": "MIT",
-      "dependencies": {
-        "bidi-js": "^1.0.2",
-        "troika-three-utils": "^0.52.4",
-        "troika-worker-utils": "^0.52.0",
-        "webgl-sdf-generator": "1.1.1"
-      },
-      "peerDependencies": {
-        "three": ">=0.125.0"
-      }
-    },
-    "node_modules/troika-three-utils": {
-      "version": "0.52.4",
-      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
-      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "three": ">=0.125.0"
-      }
-    },
-    "node_modules/troika-worker-utils": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
-      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
@@ -4407,43 +3841,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tunnel-rat": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
-      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "zustand": "^4.3.2"
-      }
-    },
-    "node_modules/tunnel-rat/node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4537,24 +3934,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/utility-types": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
-      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/validator": {
       "version": "13.15.26",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
@@ -4624,21 +4003,11 @@
         }
       }
     },
-    "node_modules/webgl-constants": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
-      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
-    },
-    "node_modules/webgl-sdf-generator": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
-      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
-      "license": "MIT"
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4678,35 +4047,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
-      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     }
   }

--- a/pokecard/package.json
+++ b/pokecard/package.json
@@ -19,10 +19,7 @@
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.69",
-    "@react-three/drei": "^10.7.3",
-    "@react-three/fiber": "^9.3.0",
     "@stripe/stripe-js": "^2.4.0",
-    "@types/three": "^0.179.0",
     "bcryptjs": "^3.0.2",
     "express-validator": "^7.2.1",
     "framer-motion": "^12.19.2",
@@ -30,8 +27,7 @@
     "lucide-react": "^0.556.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2",
-    "three": "^0.179.1"
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/pokecard/src/App.tsx
+++ b/pokecard/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, lazy, Suspense } from 'react';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { Home } from './Home';
 import styles from './App.module.css';
@@ -10,8 +11,8 @@ import { AuthProvider } from './authContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 
 // Routes chargées à la demande (code-splitting) pour alléger le bundle initial.
-// Les pages publiques secondaires, le compte, l'admin et les libs lourdes (Three.js
-// via ProductDetail/Trade) ne sont téléchargées que lorsqu'elles sont visitées.
+// Les pages publiques secondaires, le compte et l'admin ne sont téléchargés que
+// lorsqu'ils sont visités.
 const Concours = lazy(() => import('./Concours').then((m) => ({ default: m.Concours })));
 const ProductDetail = lazy(() =>
   import('./ProductDetail').then((m) => ({ default: m.ProductDetail }))
@@ -304,7 +305,12 @@ export default function App() {
     <DarkModeProvider>
       <AuthProvider>
         <ErrorBoundary>
-          <AppContent />
+          {/* LazyMotion + composant `m` : ne charge que le sous-ensemble
+              domAnimation (animations, variants, gestures) au lieu d'embarquer
+              tout framer-motion via le composant `motion`. */}
+          <LazyMotion features={domAnimation} strict>
+            <AppContent />
+          </LazyMotion>
         </ErrorBoundary>
       </AuthProvider>
     </DarkModeProvider>

--- a/pokecard/src/Concours.tsx
+++ b/pokecard/src/Concours.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Seo } from './components/Seo';
 import { AnimatedSection } from './components/AnimatedSection';
 import { AnimatedGrid } from './components/AnimatedGrid';
@@ -480,7 +480,7 @@ export function Concours() {
             }}
           >
             {pastContests.map((contest) => (
-              <motion.div
+              <m.div
                 key={contest.id}
                 whileHover={{
                   scale: 1.02,
@@ -574,7 +574,7 @@ export function Concours() {
                     <div style={{ fontSize: '1rem', fontWeight: '600' }}>{contest.winner}</div>
                   </div>
                 )}
-              </motion.div>
+              </m.div>
             ))}
           </div>
         </AnimatedGrid>
@@ -597,7 +597,7 @@ export function Concours() {
             padding: '20px',
           }}
         >
-          <motion.div
+          <m.div
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.8, opacity: 0 }}
@@ -749,7 +749,7 @@ export function Concours() {
                 )}
               </button>
             </form>
-          </motion.div>
+          </m.div>
         </div>
       )}
     </div>

--- a/pokecard/src/TradePage.tsx
+++ b/pokecard/src/TradePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Seo } from './components/Seo';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { API_BASE } from './api';
 import { handleImageError } from './utils/imageFallback';
 import styles from './TradePage.module.css';
@@ -114,7 +114,7 @@ export function TradePage() {
         </div>
 
         {/* Header */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
@@ -125,10 +125,10 @@ export function TradePage() {
           <p className={styles.description}>
             Découvrez et échangez des cartes de toutes les séries Pokémon et One Piece
           </p>
-        </motion.div>
+        </m.div>
 
         {/* Barre de recherche et filtres */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.1 }}
@@ -156,10 +156,10 @@ export function TradePage() {
               </option>
             ))}
           </select>
-        </motion.div>
+        </m.div>
 
         {/* Statistiques */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.2 }}
@@ -173,11 +173,11 @@ export function TradePage() {
             <div className={styles.statValue}>{filteredSets.length}</div>
             <div className={styles.statLabel}>Résultats</div>
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Grille des extensions */}
         {filteredSets.length === 0 ? (
-          <motion.div
+          <m.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5, delay: 0.3 }}
@@ -186,11 +186,11 @@ export function TradePage() {
             <div className={styles.emptyIcon}>🔍</div>
             <h3 className={styles.emptyTitle}>Aucune extension trouvée</h3>
             <p className={styles.emptyText}>Essayez de modifier vos critères de recherche</p>
-          </motion.div>
+          </m.div>
         ) : (
           <div className={styles.setsGrid}>
             {filteredSets.map((set) => (
-              <motion.div
+              <m.div
                 key={set.id}
                 initial={false}
                 animate={{ opacity: 1 }}
@@ -235,7 +235,7 @@ export function TradePage() {
 
                   <div className={styles.setArrow}>→</div>
                 </div>
-              </motion.div>
+              </m.div>
             ))}
           </div>
         )}

--- a/pokecard/src/TradeSetPage.tsx
+++ b/pokecard/src/TradeSetPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import HoloCard from './HoloCard';
 import { loadFoilMap } from './foilMap';
 import { API_BASE } from './api';
@@ -81,7 +81,7 @@ export function TradeSetPage() {
     <div className={styles.page}>
       <div className={styles.container}>
         {/* Header */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
@@ -94,10 +94,10 @@ export function TradeSetPage() {
           <h1 className={styles.title}>Série {id}</h1>
           <div className={styles.divider}></div>
           <p className={styles.description}>{cards.length} cartes disponibles</p>
-        </motion.div>
+        </m.div>
 
         {/* Barre de recherche et filtres */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.1 }}
@@ -125,10 +125,10 @@ export function TradeSetPage() {
               </option>
             ))}
           </select>
-        </motion.div>
+        </m.div>
 
         {/* Statistiques */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.2 }}
@@ -146,11 +146,11 @@ export function TradeSetPage() {
             <div className={styles.statValue}>{rarityOptions.length}</div>
             <div className={styles.statLabel}>Raretés</div>
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Grille des cartes */}
         {filteredCards.length === 0 ? (
-          <motion.div
+          <m.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5, delay: 0.3 }}
@@ -159,16 +159,16 @@ export function TradeSetPage() {
             <div className={styles.emptyIcon}>🔍</div>
             <h3 className={styles.emptyTitle}>Aucune carte trouvée</h3>
             <p className={styles.emptyText}>Essayez de modifier vos critères de recherche</p>
-          </motion.div>
+          </m.div>
         ) : (
-          <motion.div
+          <m.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.3 }}
             className={styles.cardsGrid}
           >
             {filteredCards.map((card) => (
-              <motion.div
+              <m.div
                 key={card.id}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -203,9 +203,9 @@ export function TradeSetPage() {
                     <button className={styles.tradeButton}>💰 Échanger</button>
                   </div>
                 </div>
-              </motion.div>
+              </m.div>
             ))}
-          </motion.div>
+          </m.div>
         )}
       </div>
     </div>

--- a/pokecard/src/components/AnimatedGrid.tsx
+++ b/pokecard/src/components/AnimatedGrid.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { useInView } from '../hooks/useInView';
 import { ReactNode } from 'react';
 
@@ -48,7 +48,7 @@ export function AnimatedGrid({
   };
 
   return (
-    <motion.div
+    <m.div
       ref={ref}
       className={className}
       variants={containerVariants}
@@ -57,13 +57,13 @@ export function AnimatedGrid({
     >
       {Array.isArray(children) ? (
         children.map((child, index) => (
-          <motion.div key={index} variants={itemVariants}>
+          <m.div key={index} variants={itemVariants}>
             {child}
-          </motion.div>
+          </m.div>
         ))
       ) : (
-        <motion.div variants={itemVariants}>{children}</motion.div>
+        <m.div variants={itemVariants}>{children}</m.div>
       )}
-    </motion.div>
+    </m.div>
   );
 }

--- a/pokecard/src/components/AnimatedSection.tsx
+++ b/pokecard/src/components/AnimatedSection.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { useInView } from '../hooks/useInView';
 import type { ReactNode } from 'react';
 
@@ -47,7 +47,7 @@ export function AnimatedSection({
   const [ref, isInView] = useInView({ threshold: 0.1, triggerOnce: true });
 
   return (
-    <motion.div
+    <m.div
       ref={ref}
       className={className}
       initial="hidden"
@@ -60,6 +60,6 @@ export function AnimatedSection({
       }}
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }

--- a/pokecard/src/components/landing/HeroRotatingCard.tsx
+++ b/pokecard/src/components/landing/HeroRotatingCard.tsx
@@ -32,7 +32,7 @@ const cards = [
 export default function HeroRotatingCard() {
   const [index, setIndex] = useState(0);
   const [isFlipping, setIsFlipping] = useState(false);
-  const [autoRotation, setAutoRotation] = useState({ x: 0, y: 0 });
+  const cardRef = useRef<HTMLDivElement>(null);
   const timeRef = useRef(0);
 
   useEffect(() => {
@@ -74,7 +74,12 @@ export default function HeroRotatingCard() {
       lastX = smoothX;
       lastY = smoothY;
 
-      setAutoRotation({ x: smoothX, y: smoothY });
+      // On écrit directement le transform sur le DOM plutôt que via un state :
+      // évite un re-render React à chaque frame (~60 fps) qui saturait le thread
+      // principal sur mobile.
+      if (cardRef.current) {
+        cardRef.current.style.transform = `perspective(1200px) rotateY(${smoothX}deg) rotateX(${-smoothY}deg)`;
+      }
 
       rafId = requestAnimationFrame(animate);
     };
@@ -92,17 +97,15 @@ export default function HeroRotatingCard() {
 
   return (
     <div className={styles.cardWrapper}>
-      <div
-        className={`${styles.card} ${isFlipping ? styles.flipping : ''}`}
-        style={{
-          transform: `perspective(1200px) rotateY(${autoRotation.x}deg) rotateX(${-autoRotation.y}deg)`,
-        }}
-      >
+      <div ref={cardRef} className={`${styles.card} ${isFlipping ? styles.flipping : ''}`}>
         <img
           src={card.image}
           alt={card.name}
           className={styles.cardImage}
-          loading="lazy"
+          width={280}
+          height={390}
+          loading="eager"
+          fetchPriority="high"
           decoding="async"
           onError={handleImageError}
         />

--- a/pokecard/src/components/landing/HeroSection.tsx
+++ b/pokecard/src/components/landing/HeroSection.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState, useRef, useMemo } from 'react';
-import { motion, useReducedMotion } from 'framer-motion';
+import { m, useReducedMotion } from 'framer-motion';
 import { ArrowRightIcon } from '../icons/Icons';
 import styles from './HeroSection.module.css';
 
@@ -231,35 +231,35 @@ export default function HeroSection() {
 
       <div className={styles.heroContainer}>
         {/* Contenu textuel avec animations stagger */}
-        <motion.div
+        <m.div
           className={styles.heroContent}
           variants={containerVariants}
           initial="hidden"
           animate="visible"
         >
-          <motion.div className={styles.universeBadge} variants={itemVariants}>
+          <m.div className={styles.universeBadge} variants={itemVariants}>
             <span className={styles.universeDot} />
             <span>{currentProduct.universe}</span>
-          </motion.div>
+          </m.div>
 
           <h1 className={styles.title}>
-            <motion.span className={styles.titleMain} variants={itemVariants}>
+            <m.span className={styles.titleMain} variants={itemVariants}>
               Découvrez.
-            </motion.span>
-            <motion.span className={styles.titleMain} variants={itemVariants}>
+            </m.span>
+            <m.span className={styles.titleMain} variants={itemVariants}>
               Collectionnez.
-            </motion.span>
-            <motion.span className={styles.titleAccent} variants={itemVariants}>
+            </m.span>
+            <m.span className={styles.titleAccent} variants={itemVariants}>
               Play your cards.
-            </motion.span>
+            </m.span>
           </h1>
 
-          <motion.p className={styles.description} variants={itemVariants}>
+          <m.p className={styles.description} variants={itemVariants}>
             Boulevard propose des produits scellés pour les passionnés de cartes à collectionner.
-          </motion.p>
+          </m.p>
 
-          <motion.div className={styles.heroActions} variants={itemVariants}>
-            <motion.button
+          <m.div className={styles.heroActions} variants={itemVariants}>
+            <m.button
               onClick={() => navigate('/produits')}
               className={styles.primaryCta}
               whileHover={{ scale: shouldReduceMotion ? 1 : 1.02, y: shouldReduceMotion ? 0 : -1 }}
@@ -268,11 +268,11 @@ export default function HeroSection() {
             >
               <span>Explorer la boutique</span>
               <ArrowRightIcon size={18} />
-            </motion.button>
-          </motion.div>
+            </m.button>
+          </m.div>
 
           {/* Product indicators */}
-          <motion.div className={styles.cardIndicators} variants={itemVariants}>
+          <m.div className={styles.cardIndicators} variants={itemVariants}>
             {HERO_PRODUCTS.map((product, index) => (
               <button
                 key={product.id}
@@ -283,11 +283,11 @@ export default function HeroSection() {
                 <span className={styles.indicatorProgress} />
               </button>
             ))}
-          </motion.div>
-        </motion.div>
+          </m.div>
+        </m.div>
 
         {/* Produit en vedette */}
-        <motion.div
+        <m.div
           className={styles.heroVisual}
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
@@ -325,7 +325,7 @@ export default function HeroSection() {
               <span className={styles.cardSubtitle}>{currentProduct.subtitle}</span>
             </div>
           </div>
-        </motion.div>
+        </m.div>
       </div>
 
       {/* Indicateur scroll - centré en bas de la section */}

--- a/pokecard/src/components/navbar/NavbarGlass.tsx
+++ b/pokecard/src/components/navbar/NavbarGlass.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
-import { motion, useReducedMotion, AnimatePresence } from 'framer-motion';
+import { m, useReducedMotion, AnimatePresence } from 'framer-motion';
 import { CartContext, type Product as ProductType } from '../../cartContext';
 import { useAuth } from '../../authContext';
 import { useDarkMode } from '../../contexts/useDarkMode';
@@ -325,7 +325,7 @@ export default function NavbarGlass() {
   };
 
   return (
-    <motion.nav
+    <m.nav
       className={styles.navbar}
       initial="initial"
       animate="animate"
@@ -336,7 +336,7 @@ export default function NavbarGlass() {
       <div className={styles.pill}>
         <div className={styles.container}>
           {/* Logo (Gauche) */}
-          <motion.button
+          <m.button
             className={styles.logo}
             onClick={() => navigate('/')}
             aria-label="Retour à l'accueil"
@@ -350,7 +350,7 @@ export default function NavbarGlass() {
               className={styles.logoImage}
               onError={handleImageError}
             />
-          </motion.button>
+          </m.button>
 
           {/* Navigation Centrale */}
           <ul className={styles.navLinks} role="list">
@@ -368,24 +368,24 @@ export default function NavbarGlass() {
                     onMouseLeave={() => setHoveredItem(null)}
                     aria-current={isActive ? 'page' : undefined}
                   >
-                    <motion.span
+                    <m.span
                       variants={navLinkVariants}
                       initial="rest"
                       animate={isActive ? 'active' : isHovered ? 'hover' : 'rest'}
                       className={styles.navLinkText}
                     >
                       {item.label}
-                    </motion.span>
+                    </m.span>
 
-                    {/* Underline animé avec layoutId */}
+                    {/* Soulignement de l'item actif/survolé : fondu d'opacité
+                        (compatible LazyMotion domAnimation, sans feature layout). */}
                     {shouldShowUnderline && (
-                      <motion.div
+                      <m.div
                         className={styles.underline}
-                        layoutId="navbar-underline"
-                        initial={false}
-                        transition={
-                          shouldReduceMotion ? { duration: 0.2, ease: 'easeInOut' } : SPRING_CONFIG
-                        }
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.2, ease: 'easeInOut' }}
                       />
                     )}
                   </Link>
@@ -399,7 +399,7 @@ export default function NavbarGlass() {
             {/* Recherche avec autocomplétion */}
             <div className={styles.searchWrapper} ref={searchResultsRef}>
               <form onSubmit={handleSearch} className={styles.searchForm}>
-                <motion.div
+                <m.div
                   className={`${styles.searchContainer} ${isSearchFocused ? styles.searchFocused : ''} ${showSearchResults ? styles.searchContainerOpen : ''}`}
                   whileHover={{ scale: shouldReduceMotion ? 1 : 1.02 }}
                   transition={shouldReduceMotion ? { duration: 0.15 } : SPRING_CONFIG}
@@ -428,13 +428,13 @@ export default function NavbarGlass() {
                     aria-autocomplete="list"
                   />
                   {isSearching && <div className={styles.searchSpinner} />}
-                </motion.div>
+                </m.div>
               </form>
 
               {/* Résultats de recherche */}
               <AnimatePresence>
                 {showSearchResults && searchResults.length > 0 && (
-                  <motion.div
+                  <m.div
                     className={styles.searchResults}
                     initial={{ opacity: 0, y: -10 }}
                     animate={{ opacity: 1, y: 0 }}
@@ -483,7 +483,7 @@ export default function NavbarGlass() {
                         )
                       );
                     })()}
-                  </motion.div>
+                  </m.div>
                 )}
               </AnimatePresence>
             </div>
@@ -499,7 +499,7 @@ export default function NavbarGlass() {
               className={styles.themeToggle}
             >
               <AnimatePresence mode="wait" initial={false}>
-                <motion.span
+                <m.span
                   key={isDark ? 'moon' : 'sun'}
                   initial={{ scale: 0.5, opacity: 0, rotate: -90 }}
                   animate={{ scale: 1, opacity: 1, rotate: 0 }}
@@ -508,12 +508,12 @@ export default function NavbarGlass() {
                   className={styles.themeIconWrapper}
                 >
                   {isDark ? <MoonIcon size={16} /> : <SunIcon size={16} />}
-                </motion.span>
+                </m.span>
               </AnimatePresence>
             </LiquidMetalIconButton>
 
             {/* Panier (toujours visible) */}
-            <motion.button
+            <m.button
               onClick={() => navigate('/panier')}
               className={styles.iconButton}
               aria-label={`Panier${cartCount > 0 ? ` (${cartCount} articles)` : ''}`}
@@ -524,22 +524,22 @@ export default function NavbarGlass() {
             >
               <CartIcon size={18} />
               {cartCount > 0 && (
-                <motion.span
+                <m.span
                   className={styles.cartBadge}
                   initial={{ scale: 0 }}
                   animate={{ scale: 1 }}
                   transition={shouldReduceMotion ? { duration: 0.2 } : SPRING_CONFIG}
                 >
                   {cartCount > 9 ? '9+' : cartCount}
-                </motion.span>
+                </m.span>
               )}
-            </motion.button>
+            </m.button>
 
             {/* Utilisateur connecté ou non */}
             {isAuthenticated && user ? (
               <>
                 {user.isAdmin && (
-                  <motion.button
+                  <m.button
                     onClick={() => navigate('/admin/dashboard')}
                     className={styles.iconButton}
                     aria-label="Dashboard Admin"
@@ -549,10 +549,10 @@ export default function NavbarGlass() {
                     whileTap="tap"
                   >
                     <DashboardIcon size={16} />
-                  </motion.button>
+                  </m.button>
                 )}
 
-                <motion.button
+                <m.button
                   onClick={() => navigate('/profile')}
                   className={styles.userButton}
                   aria-label="Mon compte"
@@ -563,9 +563,9 @@ export default function NavbarGlass() {
                 >
                   <UserIcon size={16} />
                   <span className={styles.userName}>{user.firstName || user.username}</span>
-                </motion.button>
+                </m.button>
 
-                <motion.button
+                <m.button
                   onClick={logout}
                   className={styles.iconButton}
                   aria-label="Se déconnecter"
@@ -575,7 +575,7 @@ export default function NavbarGlass() {
                   whileTap="tap"
                 >
                   <LogOutIcon size={16} />
-                </motion.button>
+                </m.button>
               </>
             ) : (
               <Link to="/login" className={styles.signInLink} aria-label="Se connecter">
@@ -584,7 +584,7 @@ export default function NavbarGlass() {
             )}
 
             {/* Bouton menu mobile */}
-            <motion.button
+            <m.button
               className={styles.mobileMenuButton}
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
               aria-label={isMobileMenuOpen ? 'Fermer le menu' : 'Ouvrir le menu'}
@@ -595,7 +595,7 @@ export default function NavbarGlass() {
               whileTap="tap"
             >
               {isMobileMenuOpen ? <CloseIcon size={20} /> : <MenuIcon size={20} />}
-            </motion.button>
+            </m.button>
           </div>
         </div>
       </div>
@@ -607,7 +607,7 @@ export default function NavbarGlass() {
             {isMobileMenuOpen && (
               <div key="mobile-menu" className={styles.mobileMenuWrapper}>
                 {/* Overlay */}
-                <motion.div
+                <m.div
                   className={styles.mobileOverlay}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
@@ -618,7 +618,7 @@ export default function NavbarGlass() {
                 />
 
                 {/* Menu mobile slide depuis le bas */}
-                <motion.div
+                <m.div
                   className={styles.mobileMenu}
                   initial={{ y: '100%' }}
                   animate={{ y: 0 }}
@@ -695,7 +695,7 @@ export default function NavbarGlass() {
                     {/* Résultats de recherche mobile */}
                     <AnimatePresence>
                       {showSearchResults && searchResults.length > 0 && (
-                        <motion.div
+                        <m.div
                           className={styles.mobileSearchResults}
                           initial={{ opacity: 0, y: -10 }}
                           animate={{ opacity: 1, y: 0 }}
@@ -749,7 +749,7 @@ export default function NavbarGlass() {
                               )
                             );
                           })()}
-                        </motion.div>
+                        </m.div>
                       )}
                     </AnimatePresence>
                   </div>
@@ -779,7 +779,7 @@ export default function NavbarGlass() {
                   {/* Actions mobile */}
                   <div className={styles.mobileActions}>
                     {/* Toggle thème mobile */}
-                    <motion.button
+                    <m.button
                       onClick={toggleDarkMode}
                       className={styles.mobileActionButton}
                       aria-label={isDark ? 'Activer le mode clair' : 'Activer le mode sombre'}
@@ -788,9 +788,9 @@ export default function NavbarGlass() {
                     >
                       {isDark ? <MoonIcon size={20} /> : <SunIcon size={20} />}
                       <span>{isDark ? 'Mode sombre' : 'Mode clair'}</span>
-                    </motion.button>
+                    </m.button>
 
-                    <motion.button
+                    <m.button
                       onClick={() => {
                         navigate('/panier');
                         closeMenu();
@@ -806,12 +806,12 @@ export default function NavbarGlass() {
                           {cartCount > 9 ? '9+' : cartCount}
                         </span>
                       )}
-                    </motion.button>
+                    </m.button>
 
                     {isAuthenticated && user ? (
                       <>
                         {user.isAdmin && (
-                          <motion.button
+                          <m.button
                             onClick={() => {
                               navigate('/admin/dashboard');
                               closeMenu();
@@ -822,10 +822,10 @@ export default function NavbarGlass() {
                           >
                             <DashboardIcon size={20} />
                             <span>Dashboard Admin</span>
-                          </motion.button>
+                          </m.button>
                         )}
 
-                        <motion.button
+                        <m.button
                           onClick={() => {
                             navigate('/profile');
                             closeMenu();
@@ -836,9 +836,9 @@ export default function NavbarGlass() {
                         >
                           <UserIcon size={20} />
                           <span>{user.firstName || user.username}</span>
-                        </motion.button>
+                        </m.button>
 
-                        <motion.button
+                        <m.button
                           onClick={() => {
                             logout();
                             closeMenu();
@@ -849,7 +849,7 @@ export default function NavbarGlass() {
                         >
                           <LogOutIcon size={20} />
                           <span>Déconnexion</span>
-                        </motion.button>
+                        </m.button>
                       </>
                     ) : (
                       <Link
@@ -863,12 +863,12 @@ export default function NavbarGlass() {
                       </Link>
                     )}
                   </div>
-                </motion.div>
+                </m.div>
               </div>
             )}
           </AnimatePresence>,
           document.body
         )}
-    </motion.nav>
+    </m.nav>
   );
 }

--- a/pokecard/src/components/ui/LiquidMetalIconButton.tsx
+++ b/pokecard/src/components/ui/LiquidMetalIconButton.tsx
@@ -1,6 +1,12 @@
-import { type ReactNode, useState, useEffect, useMemo } from 'react';
-import { LiquidMetal } from '@paper-design/shaders-react';
+import { type ReactNode, useState, useEffect, useMemo, lazy, Suspense } from 'react';
 import styles from './LiquidMetalIconButton.module.css';
+
+// Le shader WebGL (@paper-design/shaders-react) est purement décoratif : on le
+// charge à la demande pour le sortir du bundle initial servi sur chaque page.
+// Le fallbackRing s'affiche pendant le chargement.
+const LiquidMetal = lazy(() =>
+  import('./liquidMetalShader').then((m) => ({ default: m.LiquidMetal }))
+);
 
 interface LiquidMetalIconButtonProps {
   size?: number;
@@ -105,15 +111,17 @@ export function LiquidMetalIconButton({
         <span className={styles.fallbackRing} aria-hidden="true" />
       ) : (
         <span className={styles.shaderRing} aria-hidden="true">
-          <LiquidMetal
-            className={styles.shaderCanvas}
-            colorBack={shader.colorBack}
-            colorTint={shader.colorTint}
-            distortion={shader.distortion}
-            speed={shader.speed}
-            minPixelRatio={1}
-            maxPixelCount={120000}
-          />
+          <Suspense fallback={<span className={styles.fallbackRing} />}>
+            <LiquidMetal
+              className={styles.shaderCanvas}
+              colorBack={shader.colorBack}
+              colorTint={shader.colorTint}
+              distortion={shader.distortion}
+              speed={shader.speed}
+              minPixelRatio={1}
+              maxPixelCount={120000}
+            />
+          </Suspense>
         </span>
       )}
 

--- a/pokecard/src/components/ui/liquidMetalShader.ts
+++ b/pokecard/src/components/ui/liquidMetalShader.ts
@@ -1,0 +1,4 @@
+// Point d'entrée isolé pour le chargement à la demande du shader LiquidMetal.
+// En ne ré-exportant QUE LiquidMetal, le chunk lazy ne contient que ce shader
+// (tree-shaking préservé) au lieu de toute la librairie @paper-design/shaders.
+export { LiquidMetal } from '@paper-design/shaders-react';

--- a/pokecard/vite.config.ts
+++ b/pokecard/vite.config.ts
@@ -5,19 +5,30 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   build: {
-    // Découpage des dépendances lourdes en chunks séparés pour qu'elles
-    // ne pèsent pas sur le bundle initial et soient mises en cache durablement.
+    // Découpage des dépendances lourdes en chunks vendor stables, mis en cache
+    // durablement et séparés du code applicatif (qui change à chaque déploiement).
+    // La forme fonction est nécessaire pour capturer react-dom/client (createRoot),
+    // que la forme tableau ['react-dom'] laissait fuir dans le bundle d'entrée.
     rollupOptions: {
       output: {
-        manualChunks: {
-          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-          three: ['three', '@react-three/fiber', '@react-three/drei'],
-          motion: ['framer-motion'],
-          stripe: ['@stripe/stripe-js'],
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
+          if (id.includes('framer-motion') || id.includes('/motion-dom/')) return 'motion';
+          if (id.includes('@stripe')) return 'stripe';
+          // Coeur React (react + react-dom + scheduler + router) regroupé.
+          if (
+            id.includes('/react-dom/') ||
+            id.includes('/scheduler/') ||
+            id.includes('/react-router') ||
+            /[\\/]react[\\/]/.test(id)
+          ) {
+            return 'react-vendor';
+          }
+          // @paper-design (shader LiquidMetal) laissé non routé : il reste ainsi
+          // dans son chunk dynamique (chargé à la demande).
         },
       },
     },
-    // Remonte le seuil d'alerte : les chunks 3D restent volumineux par nature.
-    chunkSizeWarningLimit: 1200,
+    chunkSizeWarningLimit: 1000,
   },
 });


### PR DESCRIPTION
- Supprime les deps mortes three/@react-three/* (non importees) qui etaient prechargees via manualChunks sur chaque page (~182 KB).
- vite.config: manualChunks en forme fonction pour capturer react-dom/client (createRoot) qui fuyait dans l'entree -> react-vendor stable, entree 270->89 KB.
- Lazy-load du shader LiquidMetal (@paper-design) via un wrapper preservant le tree-shaking (37 KB en chunk differe au lieu de l'entree).
- framer-motion: LazyMotion + composant m (domAnimation), motion 117->75 KB. Le soulignement navbar (layoutId) devient un fondu d'opacite (feature layout absente de domAnimation).
- HeroRotatingCard: remplace setState 60fps par ecriture DOM via ref (reduit le travail du thread principal); image hero en loading=eager + fetchPriority=high
  + dimensions explicites (LCP/CLS).