### PR TITLE
feat(analytics): event purchase GA4 serveur via Measurement Protocol

### DIFF
--- a/pokecard/src/api.ts
+++ b/pokecard/src/api.ts
@@ -1,4 +1,19 @@
 import { PLACEHOLDER_IMAGE } from './utils/imageFallback';
+import { getStoredConsent } from './lib/analytics';
+
+/**
+ * Lit l'identifiant client GA depuis le cookie `_ga`, uniquement si l'utilisateur
+ * a consenti aux cookies analytiques. Sans consentement, GA n'a pas été chargé,
+ * donc pas de cookie → on ne transmet rien (cohérent avec la gestion RGPD).
+ * Format du cookie : `GA1.1.<random>.<timestamp>` → on garde `<random>.<timestamp>`.
+ */
+function readGaClientId(): string | undefined {
+  if (typeof document === 'undefined' || getStoredConsent() !== 'granted') return undefined;
+  const match = document.cookie.match(/(?:^|;\s*)_ga=([^;]+)/);
+  if (!match) return undefined;
+  const clientId = decodeURIComponent(match[1]).replace(/^GA\d\.\d\./, '');
+  return /^\d+\.\d+$/.test(clientId) ? clientId : undefined;
+}
 
 // URL de base de l'API (avec /api)
 export const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8080/api';
@@ -132,6 +147,7 @@ export async function createCheckoutSession(
       cancelUrl,
       shipping,
       shippingMethodCode,
+      gaClientId: readGaClientId(),
     };
 
     const res = await fetch(`${API_BASE}/checkout/create-session`, {

--- a/server/env.example
+++ b/server/env.example
@@ -57,6 +57,11 @@ STRIPE_API_VERSION="2024-06-20"
 CHECKOUT_SUCCESS_URL="http://localhost:3000/checkout/success"
 CHECKOUT_CANCEL_URL="http://localhost:3000/panier"
 
+# Google Analytics 4 — Measurement Protocol (event purchase serveur, optionnel)
+# Si vide, l'envoi est désactivé (no-op). API Secret : GA4 > Admin > Flux de données > Protocole de mesure.
+GA4_MEASUREMENT_ID="G-48XSD96XGF"
+GA4_API_SECRET="VOTRE_API_SECRET_GA4"
+
 # Emails (SMTP)
 SMTP_HOST="smtp.gmail.com"
 SMTP_PORT=587

--- a/server/src/routes/checkout.ts
+++ b/server/src/routes/checkout.ts
@@ -6,6 +6,7 @@ import Stripe from 'stripe';
 import { ensureStripeConfigured } from '../config/stripe.js';
 import { optionalAuth } from '../middleware/auth.js';
 import { sendOrderConfirmationEmail } from '../services/email.js';
+import { sendGa4Purchase, parseGaClientId, type Ga4PurchaseItem } from '../services/ga4.js';
 import { findShippingMethod } from '../config/shipping.js';
 
 const router = Router();
@@ -162,12 +163,27 @@ async function createOrderFromSession(
   return createdOrder;
 }
 
-async function processCompletedCheckoutSession(session: Stripe.Checkout.Session) {
+type CompletedSessionResult = {
+  // `true` uniquement quand la commande vient d'être créée par cet appel.
+  // Sert à n'envoyer l'évènement GA4 qu'une seule fois, même si Stripe rejoue
+  // le webhook (la création de commande étant idempotente).
+  created: boolean;
+  ga4: {
+    transactionId: string;
+    valueCents: number;
+    currency: string;
+    items: Ga4PurchaseItem[];
+  } | null;
+};
+
+async function processCompletedCheckoutSession(
+  session: Stripe.Checkout.Session
+): Promise<CompletedSessionResult> {
   const customerEmailFromForm = session.metadata?.customerEmail || session.customer_details?.email;
   const items = parseMetadataItems(session.metadata ?? null);
 
   if (items.length === 0) {
-    return;
+    return { created: false, ga4: null };
   }
 
   const variantIds = items.map((item) => item.variantId);
@@ -176,14 +192,14 @@ async function processCompletedCheckoutSession(session: Stripe.Checkout.Session)
       ? session.metadata.userId
       : null;
 
-  await prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx): Promise<CompletedSessionResult> => {
     // Idempotence à l'intérieur de la transaction (protège contre les webhooks simultanés)
     const existingOrder = await tx.order.findFirst({
       where: { stripeSessionId: session.id },
       select: { id: true },
     });
     if (existingOrder) {
-      return;
+      return { created: false, ga4: null };
     }
 
     const variants = await tx.productVariant.findMany({
@@ -301,6 +317,25 @@ async function processCompletedCheckoutSession(session: Stripe.Checkout.Session)
         },
       },
     });
+
+    // Données pour GA4 (montants relus depuis la DB, pas du payload client).
+    return {
+      created: true,
+      ga4: {
+        transactionId: orderNumber,
+        valueCents: totalCents,
+        currency,
+        items: orderItemsData.map((item) => ({
+          item_id: item.productVariantId,
+          item_name:
+            item.variantName && item.variantName.toLowerCase() !== 'standard'
+              ? `${item.productName} – ${item.variantName}`
+              : item.productName,
+          quantity: item.quantity,
+          unitPriceCents: item.unitPriceCents,
+        })),
+      },
+    };
   });
 }
 
@@ -454,6 +489,7 @@ router.post(
       .isInt({ min: 1, max: MAX_QUANTITY_PER_ITEM })
       .withMessage(`La quantité doit être entre 1 et ${MAX_QUANTITY_PER_ITEM}.`),
     body('customerEmail').optional().isEmail().normalizeEmail().withMessage('Email invalide'),
+    body('gaClientId').optional().isString().isLength({ max: 64 }),
     body('successUrl')
       .optional()
       .isString()
@@ -857,6 +893,14 @@ router.post(
         sessionConfig.discounts = [{ coupon: stripeCouponId }];
       }
 
+      // Rattacher le client_id GA (cookie `_ga`) pour relier l'achat au parcours
+      // dans GA4 via le webhook. Validé/normalisé : on ne stocke pas de valeur
+      // forgée sur la session Stripe.
+      const gaClientId = parseGaClientId(req.body.gaClientId);
+      if (gaClientId) {
+        sessionConfig.client_reference_id = gaClientId;
+      }
+
       const session = await stripeClient.checkout.sessions.create(sessionConfig);
 
       // Stocker dans le cache d'idempotence si une clé était fournie
@@ -1082,8 +1126,10 @@ export const checkoutWebhookHandler = async (req: Request, res: Response) => {
   }
 
   if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    let result: CompletedSessionResult;
     try {
-      await processCompletedCheckoutSession(event.data.object as Stripe.Checkout.Session);
+      result = await processCompletedCheckoutSession(session);
     } catch (err: any) {
       // P2002 = violation de contrainte unique (stripeSessionId) → commande déjà créée, idempotent
       if (err?.code === 'P2002' || err?.message?.includes('stripeSessionId')) {
@@ -1093,6 +1139,18 @@ export const checkoutWebhookHandler = async (req: Request, res: Response) => {
         received: false,
         error: 'Erreur lors du traitement du webhook',
       });
+    }
+
+    // GA4 hors transaction : fire-and-forget, uniquement à la création (jamais
+    // sur un rejeu Stripe) et seulement si un client_id consenti est présent.
+    if (result.created && result.ga4 && session.client_reference_id) {
+      void sendGa4Purchase({
+        clientId: session.client_reference_id,
+        transactionId: result.ga4.transactionId,
+        valueCents: result.ga4.valueCents,
+        currency: result.ga4.currency,
+        items: result.ga4.items,
+      }).catch(() => {});
     }
   }
 

--- a/server/src/services/ga4.ts
+++ b/server/src/services/ga4.ts
@@ -1,0 +1,112 @@
+// Envoi serveur d'évènements GA4 via la Measurement Protocol.
+//
+// Utilisé après confirmation d'un paiement Stripe (webhook) pour remonter
+// l'évènement `purchase`. Conçu pour être **non bloquant** : un échec ici ne
+// doit jamais empêcher la commande d'être créée ni provoquer un retry Stripe.
+//
+// RGPD : on n'envoie un évènement QUE si un `client_id` GA valide est fourni
+// (issu du cookie `_ga`, donc présent uniquement si l'utilisateur a consenti
+// aux cookies analytiques). Aucune PII (email, nom, adresse) n'est transmise.
+
+import logger from '../utils/logger.js';
+
+const GA4_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+const SEND_TIMEOUT_MS = 3000;
+
+export type Ga4PurchaseItem = {
+  item_id: string;
+  item_name: string;
+  quantity: number;
+  unitPriceCents: number;
+};
+
+export type Ga4PurchaseParams = {
+  /** Valeur brute du cookie `_ga` ou client_id déjà extrait. */
+  clientId: string;
+  /** Identifiant de transaction (= orderNumber), pas une PII. */
+  transactionId: string;
+  valueCents: number;
+  currency: string;
+  items: Ga4PurchaseItem[];
+};
+
+/**
+ * Extrait et valide l'identifiant client GA depuis la valeur du cookie `_ga`.
+ * Le cookie a la forme `GA1.1.<clientId>` où `clientId = "<random>.<timestamp>"`.
+ * Accepte aussi un clientId déjà extrait (`<digits>.<digits>`).
+ * Retourne `null` si le format est invalide (valeur forgée, vide, trop longue…),
+ * ce qui sert de garde-fou : `client_reference_id` est contrôlé par le client.
+ */
+export function parseGaClientId(raw: string | undefined | null): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > 64) return null;
+
+  // Retirer un éventuel préfixe "GA1.1." / "GA1.2." …
+  const clientId = trimmed.replace(/^GA\d\.\d\./, '');
+  if (!/^\d+\.\d+$/.test(clientId)) return null;
+  return clientId;
+}
+
+/**
+ * Envoie un évènement `purchase` à GA4. Fire-and-forget : n'échoue jamais
+ * l'appelant, timeout court. Ne logge JAMAIS l'URL (elle contient `api_secret`
+ * en query string), uniquement un status / message.
+ */
+export async function sendGa4Purchase(params: Ga4PurchaseParams): Promise<void> {
+  const measurementId = process.env.GA4_MEASUREMENT_ID?.trim();
+  const apiSecret = process.env.GA4_API_SECRET?.trim();
+
+  // Fonctionnalité optionnelle : non configurée → no-op silencieux.
+  if (!measurementId || !apiSecret) return;
+
+  const clientId = parseGaClientId(params.clientId);
+  if (!clientId) return; // pas de consentement / id invalide → on n'envoie rien
+
+  const body = {
+    client_id: clientId,
+    events: [
+      {
+        name: 'purchase',
+        params: {
+          transaction_id: params.transactionId,
+          currency: params.currency,
+          value: Math.round(params.valueCents) / 100,
+          items: params.items.map((item) => ({
+            item_id: item.item_id,
+            item_name: item.item_name,
+            quantity: item.quantity,
+            price: Math.round(item.unitPriceCents) / 100,
+          })),
+        },
+      },
+    ],
+  };
+
+  const url = `${GA4_ENDPOINT}?measurement_id=${encodeURIComponent(
+    measurementId
+  )}&api_secret=${encodeURIComponent(apiSecret)}`;
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+    });
+    // Ne jamais logger `url` (contient api_secret) : status uniquement.
+    if (!res.ok) {
+      logger.warn('Envoi GA4 purchase non confirmé', {
+        type: 'GA4_PURCHASE',
+        status: res.status,
+        transactionId: params.transactionId,
+      });
+    }
+  } catch (err) {
+    logger.warn('Échec envoi GA4 purchase', {
+      type: 'GA4_PURCHASE',
+      transactionId: params.transactionId,
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+  }
+}


### PR DESCRIPTION
Remonte l'achat à GA4 depuis le webhook Stripe existant (checkout.session.completed), sans nouvel endpoint. L'event purchase n'est envoyé qu'à la création de la commande (jamais sur un rejeu Stripe), avec des montants relus en DB.

RGPD : le client_id (cookie _ga) n'est transmis que si le consentement analytique est accordé ; sans client_id, aucun event serveur n'est envoyé.

Sécurité : client_reference_id validé (front + serveur + webhook), aucune PII vers GA4, api_secret jamais loggé (URL non journalisée), envoi fire-and-forget avec timeout pour ne pas bloquer le webhook.