### PR TITLE
feat(ebay): endpoint de notifications de suppression/fermeture de compte

### DIFF
--- a/server/env.example
+++ b/server/env.example
@@ -86,6 +86,14 @@ FRONTEND_INTERNAL_URL="http://pokecard-frontend:80"
 # Conservé pour rétrocompatibilité, sera supprimé dans une future version
 # FRONTEND_URL="http://localhost:5173"
 
+# eBay - notifications de suppression/fermeture de compte (Marketplace Account Deletion)
+# Token à saisir tel quel dans le Developer Portal eBay (Alerts & Notifications).
+# ⚠️ eBay exige un token de 32 à 80 caractères (alphanumérique, "_" et "-") : générez-en un long, ne gardez pas un exemple court.
+EBAY_VERIFICATION_TOKEN="mon-token-secret-123"
+# URL publique EXACTE (https, sans trailing slash) enregistrée côté eBay pour cet endpoint.
+# Doit correspondre au chemin monté dans server/src/index.ts (/ebay-notifications).
+EBAY_NOTIFICATION_ENDPOINT_URL="https://votre-domaine.com/ebay-notifications"
+
 # ===== SEED DATABASE (dev only) =====
 # Configuration pour prisma db seed
 SEED_ADMIN_EMAIL="admin@example.com"

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,6 +22,7 @@ import adminRoutes from './routes/admin.js';
 import twoFactorRoutes from './routes/twoFactor.js';
 import contactRoutes from './routes/contact.js';
 import gdprRoutes from './routes/gdpr.js';
+import ebayRoutes from './routes/ebay.js';
 
 // Import des middlewares de sécurité
 import {
@@ -175,6 +176,9 @@ app.use('/api/gdpr', gdprRoutes);
 
 // Contact (formulaire)
 app.use('/api/contact', contactRoutes);
+
+// eBay - notifications de suppression/fermeture de compte (chemin exact enregistré côté eBay)
+app.use('/ebay-notifications', ebayRoutes);
 
 // Route de santé
 app.get('/api/health', (_req, res) => res.json({ ok: true }));

--- a/server/src/routes/ebay.ts
+++ b/server/src/routes/ebay.ts
@@ -1,0 +1,79 @@
+import { Router, Request, Response } from 'express';
+import crypto from 'crypto';
+import rateLimit from 'express-rate-limit';
+import logger from '../utils/logger.js';
+
+const router = Router();
+
+const EBAY_VERIFICATION_TOKEN = process.env.EBAY_VERIFICATION_TOKEN || '';
+const EBAY_NOTIFICATION_ENDPOINT_URL = process.env.EBAY_NOTIFICATION_ENDPOINT_URL || '';
+
+// Endpoint public non authentifié (appelé par eBay) : on limite le débit par IP.
+const ebayNotificationsLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * eBay appelle ce GET (avec ?challenge_code=...) pour valider l'endpoint avant
+ * d'activer les notifications. La réponse attendue est le hash SHA-256 (hex)
+ * de challengeCode + verificationToken + endpointURL, dans { challengeResponse }.
+ * Doc: https://developer.ebay.com/api-docs/commerce/notification/overview.html
+ */
+router.get('/', (req: Request, res: Response) => {
+  const challengeCode =
+    typeof req.query.challenge_code === 'string' ? req.query.challenge_code : undefined;
+
+  logger.info('eBay notifications - challenge GET reçu', {
+    challengeCode,
+    ip: req.ip,
+  });
+
+  if (!challengeCode) {
+    return res.status(400).json({ error: 'Paramètre challenge_code manquant' });
+  }
+
+  if (!EBAY_VERIFICATION_TOKEN || !EBAY_NOTIFICATION_ENDPOINT_URL) {
+    logger.error(
+      'eBay notifications - EBAY_VERIFICATION_TOKEN ou EBAY_NOTIFICATION_ENDPOINT_URL manquant en configuration'
+    );
+    return res.status(500).json({ error: 'Configuration serveur incomplète' });
+  }
+
+  const challengeResponse = crypto
+    .createHash('sha256')
+    .update(challengeCode)
+    .update(EBAY_VERIFICATION_TOKEN)
+    .update(EBAY_NOTIFICATION_ENDPOINT_URL)
+    .digest('hex');
+
+  logger.debug('eBay notifications - challengeResponse calculé', { challengeResponse });
+
+  res.setHeader('Content-Type', 'application/json');
+  return res.status(200).json({ challengeResponse });
+});
+
+/**
+ * Notifications réelles envoyées par eBay en POST (ex: MARKETPLACE_ACCOUNT_DELETION).
+ * eBay attend un 200 rapide ; on logge puis on répond immédiatement.
+ */
+router.post('/', ebayNotificationsLimiter, (req: Request, res: Response) => {
+  logger.info('eBay notifications - notification POST reçue', {
+    topic: req.body?.metadata?.topic,
+    notificationId: req.body?.notification?.notificationId,
+    eventDate: req.body?.notification?.eventDate,
+    hasSignature: Boolean(req.get('x-ebay-signature')),
+    body: req.body,
+  });
+
+  // Note: eBay signe chaque notification via l'en-tête `x-ebay-signature`.
+  // Une vérification cryptographique complète (récupération de la clé publique via
+  // la Notification API puis vérification ECDSA) peut être ajoutée ici si nécessaire ;
+  // elle n'est pas requise pour que l'endpoint soit validé par eBay.
+
+  return res.status(200).json({ status: 'success' });
+});
+
+export default router;


### PR DESCRIPTION
Implémente le flux de validation eBay (GET challenge_code -> SHA-256 challengeResponse) et la réception des notifications (POST) sur /ebay-notifications, avec logs et token/URL configurables via env.