### PR TITLE
feat(shipping): intégration Boxtal v3 — points relais, étiquettes, tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ coverage/
 server/keys/
 *.pem
 
+# ==== OUTILLAGE LOCAL (Claude Code / BMAD) ====
+.claude/
+_bmad/
+
 # ==== AUTRES ====
 *.tgz
 *.tar.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,9 @@ services:
       # - JWT_SECRET=test_jwt_secret_key_at_least_64_characters_long_for_security_config_validation
       # - JWT_REFRESH_SECRET=test_jwt_refresh_secret_key_at_least_64_characters_long_for_security_config_validation
       - ORDER_TRACKING_SECRET=test_order_tracking_secret_key_at_least_64_characters_long_for_security_config_validation
-      - STRIPE_SECRET_KEY=sk_test_mock_key
+      # STRIPE_SECRET_KEY vient de server/.env (env_file) — clé de test réelle
+      # pour que le checkout fonctionne en local. Ancienne valeur mock :
+      # - STRIPE_SECRET_KEY=sk_test_mock_key
       # URL publique du frontend (emails, redirects, liens utilisateurs)
       # Dev: http://localhost:3000 | Prod: https://boulevardtcg.com
       - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-http://localhost:3000}

--- a/docs/PASSATION.md
+++ b/docs/PASSATION.md
@@ -1,0 +1,166 @@
+# Passation — BoulevardTCG
+
+> Document de reprise pour une nouvelle session Claude Code (ou un nouveau dev).
+> Dernière mise à jour : **2026-07-20**.
+> À lire avec `CLAUDE.md` (racine), qui couvre les commandes et l'architecture générale.
+
+---
+
+## 1. Où en est le projet
+
+Plateforme e-commerce TCG (monolithe modulaire) : boutique React + API Express + PostgreSQL, plus une app Marketplace séparée.
+
+**Le gros chantier récent, et le seul non trivial en cours : l'intégration de livraison Boxtal (API v3).** Elle a été mergée dans `main` le 2026-07-20. Elle est fonctionnellement complète pour le parcours nominal, mais comporte des angles morts documentés en §5 — c'est la section à lire avant d'y toucher.
+
+État des suites de tests au moment du merge : **416 tests backend au vert** (26 fichiers), build front OK.
+
+---
+
+## 2. Rappels d'environnement (les pièges qui font perdre du temps)
+
+- **Monorepo sans workspaces.** Ne jamais lancer `npm install` à la racine. Toujours `npm --prefix server ...` / `npm --prefix pokecard ...`.
+- **Node >= 24** pour les deux projets.
+- **Prisma : `migrate dev` veut reset la base de dev.** Ne pas l'utiliser. Écrire la migration SQL à la main dans `server/prisma/migrations/<timestamp>_<nom>/migration.sql`, puis `migrate deploy`. C'est ce qui a été fait pour Boxtal.
+- **Base de test sur le port 5434** (la base de dev est sur 5432).
+- **Marketplace** : `marketplace/server/.env` doit avoir le **même `JWT_SECRET`** que `server/.env`, sinon 401 systématique — les tokens sont émis par la Boutique et vérifiés par le Marketplace.
+- **Prod = Vercel (front) + Railway (back).** `api.boulevardtcg.com` n'existe pas ; le front tape l'URL Railway via `VITE_API_URL` (injecté au build).
+
+### Piège structurel important
+`server/src/app.ts` **et** `server/src/index.ts` déclarent chacun leurs routes, indépendamment. `app.ts` est utilisé par les tests, `index.ts` par le runtime. **Toute nouvelle route doit être ajoutée aux deux fichiers**, sinon elle passe les tests et n'existe pas en production (ou l'inverse). C'est la source de bug la plus facile à introduire dans ce repo.
+
+---
+
+## 3. Authentification (inchangé, mais souvent mal réimplémenté)
+
+- Access token : `localStorage` (`accessToken`), 15 min.
+- Refresh token : **cookie httpOnly** (`refreshToken`), path `/api/auth`, 7 jours.
+- Côté boutique, le refresh token n'est **jamais** dans le JSON de réponse ni dans `localStorage`. Ne pas « simplifier » ça : c'était une correction de sécurité (C1).
+- `/api/auth/refresh` lit le cookie en priorité, avec un repli sur le body **uniquement pour compatibilité Marketplace** (dont le front stocke le token autrement). Ne pas retirer ce repli.
+
+---
+
+## 4. L'intégration Boxtal — ce qu'il faut savoir
+
+### 4.1 Activation
+
+Tout est piloté par `BOXTAL_ACCESS_KEY` + `BOXTAL_SECRET_KEY`. Si l'une manque, `getBoxtalConfig()` (`server/src/config/boxtal.ts:101`) renvoie `null` et la fonctionnalité se désactive proprement (503 `BOXTAL_NOT_CONFIGURED`). `validateEnv` vérifie seulement que les deux sont présentes **ou** absentes ensemble.
+
+Attention : **`validateEnv` ne valide rien d'autre.** Des clés API sans codes d'offre, sans expéditeur ou sans secret webhook démarrent sans le moindre avertissement, et l'échec ne se manifeste qu'au premier clic admin. Variables complètes documentées dans `server/env.example:60-95`.
+
+Les 8 variables `BOXTAL_SHIPPER_*` (company, first name, last name, email, phone, address, postal code, city) sont **requises ensemble** : `buildShipper()` renvoie `null` si une seule manque.
+
+Par défaut `BOXTAL_API_BASE_URL` pointe l'environnement de **test** (`https://api.boxtal.build`). À basculer explicitement pour la prod.
+
+Aucune variable `BOXTAL_*` n'est dans `docker-compose.yml` — elles transitent par `server/.env`.
+
+### 4.2 Routes
+
+| Méthode + chemin | Auth | Rôle |
+|---|---|---|
+| `GET /api/shipping/methods` | publique | Modes de livraison (voir §5, actuellement non consommé par le front) |
+| `GET /api/shipping/parcel-points` | publique, 20 req/min/IP | Proxy de recherche de points relais — les clés Boxtal ne sortent jamais du serveur |
+| `POST /api/shipping/boxtal/webhook` | signature HMAC | `TRACKING_CHANGED` / `DOCUMENT_CREATED` |
+| `POST /api/admin/orders/:orderId/boxtal-shipment` | admin | Création d'étiquette, ou resynchronisation si déjà créée |
+
+Le webhook est monté **avant `express.json()`** (corps brut nécessaire au HMAC) et **exempté du rate-limit global**.
+
+### 4.3 Schéma
+
+`Order` gagne 4 colonnes nullables (migration `20260715120000_add_boxtal_shipping_fields`) :
+`boxtalShippingOrderId String? @unique`, `labelUrl String?`, `pickupPointCode String?`, `pickupPoint Json?`.
+
+Pas de nouvel enum : `FulfillmentStatus.PREPARING` et `OrderEventType.PREPARING` existaient déjà.
+
+### 4.4 Flux
+
+1. **Panier** — `ParcelPointSelector` s'affiche si le mode a `requiresPickupPoint`. Recherche auto dès 4 caractères de code postal. Le choix bloque la validation s'il manque.
+2. **Checkout** — le point relais est normalisé côté serveur (`validators/pickupPoint.ts`) puis sérialisé en **métadonnées Stripe**. Le code relais n'est **pas** revalidé auprès de Boxtal à ce stade (choix assumé, commenté dans le fichier).
+3. **Commande** — les métadonnées Stripe sont relues au webhook/retour de session et remplissent `pickupPointCode` + `pickupPoint`.
+4. **Étiquette (admin)** — bouton « Expédier via Boxtal ». L'id Boxtal est **persisté immédiatement** après création (garde anti-double-étiquette), puis suivi et étiquette sont récupérés en best-effort. La commande passe en `PREPARING`. **Aucun email n'est envoyé à cette étape.**
+5. **Tracking** — `services/fulfillment.ts` mappe les statuts Boxtal → `SHIPPED` / `DELIVERED` et déclenche les emails. Idempotent (gardes `alreadyShipped` / `alreadyDelivered`).
+6. **Webhook** — lookup par `boxtalShippingOrderId`, repli sur `shipmentExternalId`. Commande inconnue → **200** volontairement, pour éviter les rejeux en boucle.
+
+### 4.5 Sécurité du webhook
+
+En-tête `x-bxt-signature` = HMAC-SHA256 du corps brut avec `BOXTAL_WEBHOOK_SECRET`. Comparaison **timing-safe**, acceptant hex **ou** base64 (Boxtal ne documente pas l'encodage). Pas de signature → 401 ; pas de secret configuré → 503.
+
+Pas de protection anti-rejeu (ni timestamp, ni déduplication sur l'id d'événement). Les handlers étant idempotents, le cas fonctionnel est couvert ; un rejeu malveillant d'un événement capturé ne l'est pas.
+
+### 4.6 Smoke test
+
+```bash
+cd server && npx tsx scripts/boxtal-smoke.mts
+```
+Aucun script npm n'a été ajouté pour ce fichier. Le script a un garde-fou production : il refuse toute base d'API ne contenant pas `boxtal.build`, sauf `--allow-prod`. Il enchaîne recherche de relais → création d'expédition → suivi/étiquette → annulation, en exerçant le vrai code du service.
+
+---
+
+## 5. Dette connue sur Boxtal — à lire avant d'intervenir
+
+Ces points sont **connus et assumés à ce stade**, pas des oublis. Ils sont classés par risque réel.
+
+### Impact client direct
+1. **Repli téléphone dangereux** — si le client n'a pas de téléphone, c'est **celui de la boutique** qui part chez Boxtal comme contact destinataire (`services/boxtal.ts:372`). Les SMS de mise à disposition du transporteur arriveront donc à la boutique, et le client ne sera pas prévenu. À corriger en priorité si le téléphone n'est pas obligatoire au checkout.
+2. **`splitFullName` invente un nom de famille** — un client dont le nom tient en un mot part en `{ firstName: <mot>, lastName: 'BoulevardTCG' }` (`services/boxtal.ts:250`). Le nom de la boutique s'imprime sur l'étiquette du client.
+3. **`normalizeCountryIso2` tronque silencieusement** — un pays inconnu est réduit à ses 2 premières lettres. « ROYAUME-UNI » devient `RO`, soit la Roumanie (`services/boxtal.ts:295`).
+4. **`labelUrl` expire au bout de 7 jours** côté Boxtal, et rien ne la rafraîchit. Le lien « Étiquette PDF » de l'admin finit par renvoyer une erreur, sans message explicatif.
+
+### Coût / facturation
+5. **Le poids est entièrement estimé** : `150 g + 50 g × nombre d'articles`. Aucun poids réel par produit, ni en base ni au schéma. Les écarts de poids sont refacturés par le transporteur.
+6. **Dimensions de colis uniques** (24×18×8 cm) quelle que soit la commande.
+7. **Le coût réel d'expédition n'est jamais remonté** — `GET /shipping-order/{id}` n'est pas implémenté.
+
+### Exploitation
+8. **Aucune souscription webhook programmatique.** L'enregistrement des événements `DOCUMENT_CREATED` / `TRACKING_CHANGED` chez Boxtal se fait **à la main**, et le secret généré doit être recopié dans `BOXTAL_WEBHOOK_SECRET`. C'est une étape de déploiement facile à oublier — sans elle, aucun suivi ne remonte.
+9. **`cancelShippingOrder()` existe mais n'est exposée nulle part** (ni route, ni bouton). Annuler une étiquette créée par erreur impose de passer par l'espace Boxtal.
+10. **Statuts `RETURNED` / `EXCEPTION` ignorés en silence**, sans même un log (`services/boxtal.ts:534`). Un colis retourné ne laisse aucune trace applicative.
+11. **Aucune resynchronisation planifiée.** Si le webhook tombe, le seul rattrapage est un clic admin, commande par commande.
+
+### Cohérence
+12. **Les tarifs de livraison sont dupliqués** entre `pokecard/src/shippingMethods.ts` (en dur) et `server/src/config/shipping.ts`. `GET /api/shipping/methods` a été créé comme source de vérité serveur mais **n'est appelé par aucun code front** — l'endpoint est mort et les deux listes peuvent diverger silencieusement.
+13. **Fuite mineure** : `GET /api/users/orders` et `/users/orders/:id` renvoient l'objet `Order` complet sans `select`, donc `labelUrl` et `boxtalShippingOrderId` sont exposés au client final.
+
+### Couverture de tests
+Bonne sur le backend (36 tests dédiés Boxtal : config, normalisation, signature HMAC, routes, webhook, endpoint admin). **Non couverts** : `services/fulfillment.ts` en direct, l'assertion « pas de second email » sur l'idempotence, `cancelShippingOrder`, les timeouts/`BOXTAL_UNREACHABLE`, et **tout le front** (aucun test front n'existe dans ce projet).
+
+---
+
+## 6. Sécurité — corrections déjà appliquées, à ne pas défaire
+
+- **C1** — suppression du refresh token de `localStorage`, `credentials: 'include'` sur refresh/logout.
+- **H1** — rate limiting dédié 2FA (5 tentatives / 15 min / email).
+- **H3** — incrément de code promo **atomique** (`updateMany` conditionné sur `usedCount < usageLimit`). Ne pas revenir à un `update` simple : c'était une race condition exploitable.
+- **H4** — `Order.stripeSessionId @unique` + idempotence du webhook Stripe dans une transaction, avec `catch` du code Prisma `P2002`.
+- Audit 2026-06 : CVE corrigées, XSS JSON-LD corrigé. La montée vers Vite 8 a été **volontairement différée** (les vulnérabilités restantes sont dev-only).
+
+---
+
+## 7. RGPD / analytics
+
+GA4 `G-48XSD96XGF`. Le script n'est chargé **qu'après consentement**, via Google Tag Manager. Les `page_view` sont envoyés manuellement (SPA). L'event `purchase` est envoyé **côté serveur** via Measurement Protocol, depuis le webhook Stripe **et** depuis `verify-session`. Attention en cas de modification : le risque est le double comptage.
+
+---
+
+## 8. État Git au moment de la passation
+
+- Branche de travail Boxtal : `feat/boxtal-shipping`, **mergée dans `main`**.
+- **4 PRs restent ouvertes, toutes datées de janvier 2026** (~6 mois) et volontairement **non mergées** :
+  - **#93** — mise à jour de dépendances (sécurité). **En conflit** avec `main`.
+  - **#83** — système de réservation de panier. **+3014/-224 sur 26 fichiers.**
+  - **#60** — modifications de textes (+41/-33).
+  - **#57** — refonte de textes landing (+10/-14).
+
+  Elles n'ont jamais vu les changements Boxtal, CSP, GA4 ni eBay. **Ne pas les merger sans relecture** : #83 en particulier touche la gestion de stock, qui interagit directement avec le checkout modifié depuis. Le plus sain est probablement de les fermer et de réextraire ce qui vaut encore la peine.
+- Le repo compte beaucoup de branches locales anciennes déjà mergées — un nettoyage serait bienvenu.
+- `.claude/` et `_bmad/` sont des dossiers d'outillage local, désormais dans `.gitignore`.
+
+---
+
+## 9. Ce que je ferais en priorité
+
+1. **Corriger le repli téléphone (§5.1)** — c'est le seul point qui casse silencieusement l'expérience client en production.
+2. **Rendre le téléphone obligatoire au checkout**, ce qui règle le §5.1 à la racine.
+3. **Corriger `splitFullName` et `normalizeCountryIso2`** — deux bugs de données à faible effort, visibles sur l'étiquette.
+4. **Documenter (ou automatiser) la souscription webhook Boxtal** — sans elle, le suivi ne remonte pas et rien ne le signale.
+5. **Trancher sur les 4 vieilles PRs** — les fermer ou les rebaser, mais ne pas les laisser pourrir.
+6. **Brancher le front sur `GET /api/shipping/methods`** ou supprimer l'endpoint, pour lever la duplication des tarifs.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,224 @@
+# API Reference — BoulevardTCG
+
+**Generated:** 2026-03-15
+**Base URL (dev):** `http://localhost:8080/api`
+**Swagger UI:** `http://localhost:8080/api-docs` (requires `ENABLE_SWAGGER=true`)
+
+---
+
+## Response Format
+
+```typescript
+// Success
+{ data: T, meta?: { page: number, total: number, limit: number } }
+
+// Exceptions (auth routes)
+{ accessToken: string, user: object, message: string }
+
+// Error
+{ error: { code: string, message: string, details?: any } }
+```
+
+---
+
+## Authentication
+
+All protected routes require:
+```
+Authorization: Bearer <accessToken>
+```
+
+Admin routes additionally require `user.role === 'admin'`.
+
+---
+
+## Auth Routes — `/api/auth`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/register` | — | Create account |
+| POST | `/login` | — | Login, returns accessToken + sets refresh cookie |
+| POST | `/refresh` | Cookie/Body | Rotate refresh token, returns new accessToken |
+| POST | `/logout` | Cookie | Invalidate refresh token |
+| POST | `/forgot-password` | — | Send password reset email |
+| POST | `/reset-password` | — | Reset password with token |
+
+### POST `/api/auth/login`
+```json
+// Request
+{ "email": "string", "password": "string", "totpCode": "string?" }
+
+// Response
+{ "accessToken": "string", "user": { "id", "email", "role", "twoFactorEnabled" } }
+```
+
+### POST `/api/auth/refresh`
+- Reads `refreshToken` cookie (path `/api/auth`)
+- Fallback: reads `refreshToken` from request body (Marketplace compatibility)
+
+---
+
+## Products Routes — `/api/products`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/` | — | List products (paginated, filterable) |
+| GET | `/:id` | — | Get product by ID |
+| GET | `/search` | — | Search products |
+| GET | `/categories` | — | List categories |
+
+### GET `/api/products`
+**Query params:** `page`, `limit`, `category`, `search`, `minPrice`, `maxPrice`, `inStock`
+
+---
+
+## Checkout Routes — `/api/checkout`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/create-session` | Optional | Create Stripe Checkout session |
+| POST | `/webhook` | Stripe sig | Stripe event handler (order creation) |
+
+### POST `/api/checkout/create-session`
+```json
+// Request
+{
+  "items": [{ "variantId": "string", "quantity": number }],
+  "promoCode": "string?",
+  "shippingMethod": "string"
+}
+
+// Response
+{ "data": { "sessionUrl": "string" } }
+```
+
+---
+
+## Orders Routes — `/api/orders`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/` | Required | User's order history (paginated) |
+| GET | `/:id` | Required | Order details |
+| GET | `/track/:token` | — | Public order tracking via HMAC token |
+
+---
+
+## Trade Routes — `/api/trade`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/` | Required | List trade offers for user |
+| POST | `/` | Required | Create trade offer |
+| GET | `/:id` | Required | Get trade offer details |
+| PATCH | `/:id/accept` | Required | Accept trade offer |
+| PATCH | `/:id/reject` | Required | Reject trade offer |
+| DELETE | `/:id` | Required | Cancel trade offer |
+| GET | `/cards/search` | Required | Search cards for trading |
+| GET | `/cards/:id` | Required | Get card details |
+
+---
+
+## Reviews Routes — `/api/reviews`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/product/:productId` | — | Product reviews (paginated) |
+| POST | `/product/:productId` | Required | Submit review |
+| PATCH | `/:id` | Required | Edit own review |
+| DELETE | `/:id` | Required | Delete own review |
+
+---
+
+## Users Routes — `/api/users`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/me` | Required | Current user profile |
+| PATCH | `/me` | Required | Update profile |
+| GET | `/me/collection` | Required | User card collection |
+| POST | `/me/collection` | Required | Add card to collection |
+| DELETE | `/me/collection/:id` | Required | Remove from collection |
+| GET | `/me/favorites` | Required | Saved favorites |
+| POST | `/me/favorites` | Required | Add favorite |
+| DELETE | `/me/favorites/:id` | Required | Remove favorite |
+
+---
+
+## 2FA Routes — `/api/2fa`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/setup` | Required | Generate TOTP secret + QR code |
+| POST | `/verify` | Required | Verify TOTP code to enable 2FA |
+| POST | `/disable` | Required | Disable 2FA |
+
+---
+
+## Promo Routes — `/api/promo`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/validate` | — | Validate promo code |
+
+---
+
+## Contact Routes — `/api/contact`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/` | — | Send contact message (honeypot protected) |
+
+---
+
+## GDPR Routes — `/api/gdpr`
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/consent` | Required | Get consent status |
+| POST | `/consent` | Required | Update marketing consent |
+| POST | `/export` | Required | Request data export |
+| POST | `/delete` | Required | Request account deletion |
+
+---
+
+## Admin Routes — `/api/admin`
+
+> All admin routes require `role === 'admin'`
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/orders` | List all orders (paginated, filterable) |
+| GET | `/orders/:id` | Order details |
+| PATCH | `/orders/:id` | Update order (status, tracking, carrier) |
+| GET | `/products` | List all products |
+| POST | `/products` | Create product |
+| PATCH | `/products/:id` | Update product |
+| DELETE | `/products/:id` | Delete product |
+| POST | `/products/:id/images` | Upload product images |
+| GET | `/variants/:id` | Get variant |
+| PATCH | `/variants/:id` | Update variant (stock, price) |
+| GET | `/users` | List users |
+| GET | `/users/:id` | User details |
+| PATCH | `/users/:id` | Update user (role, status) |
+| GET | `/stats` | Dashboard statistics |
+| GET | `/promo-codes` | List promo codes |
+| POST | `/promo-codes` | Create promo code |
+| PATCH | `/promo-codes/:id` | Update promo code |
+| DELETE | `/promo-codes/:id` | Delete promo code |
+| GET | `/stock-notifications` | Back-in-stock subscriber list |
+
+---
+
+## Common Error Codes
+
+| Code | Description |
+|------|-------------|
+| `UNAUTHORIZED` | Missing or invalid token |
+| `FORBIDDEN` | Insufficient permissions |
+| `NOT_FOUND` | Resource not found |
+| `VALIDATION_ERROR` | Request body validation failed |
+| `DUPLICATE` | Unique constraint violation |
+| `RATE_LIMITED` | Too many requests |
+| `STRIPE_ERROR` | Stripe API error |
+| `EMAIL_ERROR` | Email send failure |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,120 @@
+# Architecture Overview — BoulevardTCG
+
+**Generated:** 2026-03-15
+**Scan level:** Deep
+**Project type:** Monorepo (multi-part: web + backend)
+
+---
+
+## Project Classification
+
+BoulevardTCG is a **TCG (Trading Card Game) e-commerce platform** built as a modular monolith, structured as a monorepo without npm workspaces. It includes a React frontend (`pokecard/`) and an Express/Prisma backend (`server/`), designed for future microservices extraction.
+
+---
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     CLIENT BROWSER                       │
+│              React 19 + Vite (port 5173/3000)           │
+└──────────────────────┬──────────────────────────────────┘
+                       │ HTTP / REST
+                       ▼
+┌─────────────────────────────────────────────────────────┐
+│              EXPRESS BACKEND (port 8080)                 │
+│         Node.js 24 + TypeScript + Prisma ORM            │
+└──────────────────────┬──────────────────────────────────┘
+                       │ Prisma Client
+                       ▼
+┌─────────────────────────────────────────────────────────┐
+│                POSTGRESQL 17 (port 5434)                 │
+│               Docker volume: ./postgres-data            │
+└─────────────────────────────────────────────────────────┘
+
+External Services:
+  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
+  │  Stripe  │  │  Email   │  │  TCGdex  │  │  Swagger │
+  │ Payments │  │ SMTP/    │  │  Card    │  │   Docs   │
+  │ Webhooks │  │ Resend   │  │  Prices  │  │ /api-docs│
+  └──────────┘  └──────────┘  └──────────┘  └──────────┘
+```
+
+---
+
+## Parts
+
+| Part | Directory | Type | Technology |
+|------|-----------|------|------------|
+| Frontend | `pokecard/` | web | React 19 + TypeScript + Vite |
+| Backend | `server/` | backend | Express + TypeScript + Prisma |
+
+---
+
+## Key Architectural Decisions
+
+### 1. Monorepo Without Workspaces
+- Scripts run via `npm --prefix <dir>`
+- No hoisted dependencies — each part manages its own `node_modules`
+- Root `package.json` provides convenience scripts (`dev:front`, `dev:back`)
+
+### 2. JWT with RS256 Asymmetric Signing
+- Private key signs tokens (backend only)
+- Public key verifies tokens (can be distributed to microservices)
+- Keys stored in `server/keys/` (git-ignored)
+- Access token: 15min, stored in `localStorage`
+- Refresh token: 7d, httpOnly cookie at `/api/auth`
+
+### 3. Stripe Checkout with Webhook-based Order Creation
+- No server-side cart state — Stripe session holds line items
+- Orders created only on successful `checkout.session.completed` webhook
+- `stripeSessionId @unique` prevents duplicate orders (idempotence)
+
+### 4. Prisma as ORM with Migration-based Schema Evolution
+- 9 migrations since December 2024
+- Connection pooling support via PgBouncer URL format
+- Singleton pattern in `server/src/lib/prisma.ts` with retry logic
+
+### 5. Write-as-you-go Logging
+- Winston with daily rotation
+- Structured JSON logs in `server/logs/`
+- Separate audit trail for sensitive operations
+
+---
+
+## Request Lifecycle
+
+```
+Request → Nginx (prod) / Vite proxy (dev)
+        → Express
+        → security.ts middleware (Helmet, CORS, rate limiting)
+        → auth.ts middleware (JWT verification, optional)
+        → Route handler
+        → Prisma ORM
+        → PostgreSQL
+        → Response { data: T } or { error: { code, message } }
+```
+
+---
+
+## Multi-Part Integration
+
+- Frontend calls backend via `VITE_API_URL` (build-time env injection)
+- No shared TypeScript types package — types duplicated where needed
+- Cookie cross-origin handled via `credentials: 'include'` on relevant requests
+
+---
+
+## Deployment Architecture
+
+```
+Internet → Caddy (TLS termination, reverse proxy)
+         → Docker network
+         ├── pokecard-frontend (Nginx, port 3000)
+         └── pokecard-backend (Node.js, port 8080)
+                └── PostgreSQL (port 5434, internal)
+```
+
+- `deployment/Caddyfile` — production TLS/proxy config
+- `deployment/e2e-smoke.mjs` — smoke test after deploy
+- `docker-compose.production.example.env` — production env template

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,0 +1,294 @@
+# Backend Documentation — server/
+
+**Generated:** 2026-03-15
+**Part type:** backend
+**Directory:** `server/`
+**Port:** 8080
+
+---
+
+## Technology Stack
+
+| Technology | Version | Purpose |
+|------------|---------|---------|
+| Node.js | >=24.0.0 | Runtime |
+| Express | 4.19.2 | HTTP framework |
+| TypeScript | 5.4.0 | Type safety |
+| Prisma | 6.15.0 | ORM |
+| PostgreSQL | 17 | Database |
+| Stripe | 14.24.0 | Payment processing |
+| jsonwebtoken | 9.0.2 | JWT (RS256) |
+| bcryptjs | 2.4.3 | Password hashing |
+| OTPAuth | 9.4.1 | 2FA / TOTP |
+| Winston | 3.19.0 | Logging with daily rotation |
+| Nodemailer | 7.0.11 | Email (SMTP) |
+| Resend | 6.7.0 | Email (transactional API) |
+| Helmet | 8.0.0 | Security headers |
+| CORS | 2.8.5 | Cross-origin requests |
+| express-rate-limit | 7.3.0 | Rate limiting |
+| Zod | 4.3.5 | Schema validation |
+| express-validator | - | Request validation |
+| Multer | 2.0.2 | File uploads |
+| TCGdex SDK | 2.7.0 | Card data & pricing |
+| Swagger | 6.2.8 | OpenAPI documentation |
+| Vitest | 4.0.16 | Unit/integration testing |
+
+---
+
+## Directory Structure
+
+```
+server/src/
+├── routes/             # API route handlers (14 files)
+├── middleware/         # Express middleware (2 files)
+├── services/           # Business logic services (1 file)
+├── config/             # App configuration (4 files)
+├── utils/              # Helper utilities (5 files)
+├── validators/         # Zod/express-validator schemas (1 file)
+├── pricing/            # TCGdex pricing integration (2 files)
+├── lib/                # Shared singletons (1 file)
+├── __tests__/          # Test files (20 files)
+├── app.ts              # Express app setup & route mounting
+├── index.ts            # Server entry point (port binding)
+└── swagger.ts          # OpenAPI spec generation
+```
+
+---
+
+## Routes
+
+| File | Mount | LOC | Key Endpoints |
+|------|-------|-----|---------------|
+| `admin.ts` | `/api/admin` | 1729 | Orders, products, users, stats |
+| `checkout.ts` | `/api/checkout` | 1102 | Stripe session, webhook |
+| `auth.ts` | `/api/auth` | 614 | Login, register, refresh, logout, 2FA |
+| `gdpr.ts` | `/api/gdpr` | ~500 | Consent, export, deletion requests |
+| `users.ts` | `/api/users` | ~450 | Profile, collection, favorites |
+| `trade-offers.ts` | `/api/trade` | ~320 | Offers CRUD, accept/reject |
+| `reviews.ts` | `/api/reviews` | ~270 | Product reviews CRUD |
+| `twoFactor.ts` | `/api/2fa` | ~250 | TOTP setup, enable/disable |
+| `products.ts` | `/api/products` | ~250 | Catalogue, search, pricing |
+| `collection.ts` | `/api/collection` | ~200 | User card collection |
+| `promo.ts` | `/api/promo` | ~150 | Promo code validation |
+| `contact.ts` | `/api/contact` | ~120 | Contact form + honeypot |
+| `orders.ts` | `/api/orders` | ~90 | User order history |
+| `checkout-simple.ts` | `/api/checkout-simple` | ~120 | Legacy checkout (deprecated) |
+
+---
+
+## Middleware
+
+### `middleware/auth.ts`
+- `authenticateToken(req, res, next)` — Verifies JWT, attaches `req.user`
+- `requireAdmin(req, res, next)` — Admin role guard
+- `optionalAuth(req, res, next)` — Attaches user if token present, continues either way
+
+### `middleware/security.ts`
+- Helmet (HTTP security headers)
+- CORS whitelist (frontend URL)
+- General rate limiter: 100 req/15min per IP
+- Auth rate limiter: 10 req/15min per IP
+- 2FA rate limiter: 5 attempts/15min per email
+- Cookie parser with signed cookies
+
+---
+
+## Configuration
+
+### `config/validateEnv.ts`
+Zod schema validating all required environment variables at startup. Fails fast if misconfigured.
+
+### `config/security.ts`
+Helmet options, CORS whitelist, rate limiter configurations.
+
+### `config/stripe.ts`
+Stripe SDK initialization with secret key.
+
+### `config/shipping.ts`
+Shipping methods constants (Colissimo, Mondial Relay, Chronopost, UPS, DHL, FedEx) with pricing tiers.
+
+---
+
+## Services
+
+### `services/email.ts`
+- Dual provider: Nodemailer (SMTP) + Resend (transactional)
+- HTML email templates for:
+  - Order confirmation
+  - Shipping notification with tracking link
+  - Password reset
+  - Stock notification
+  - Contact form acknowledgment
+
+---
+
+## Utilities
+
+| File | Purpose |
+|------|---------|
+| `utils/auth.ts` | JWT generation (access + refresh), token rotation |
+| `utils/logger.ts` | Winston instance, daily log rotation |
+| `utils/audit.ts` | Audit event logging (sensitive operations) |
+| `utils/tracking.ts` | Order tracking link generation/verification (HMAC) |
+| `utils/date.ts` | Date formatting helpers |
+| `lib/prisma.ts` | Prisma Client singleton with exponential retry |
+
+---
+
+## Authentication Flow
+
+```
+POST /api/auth/login
+  → Validate credentials
+  → Generate accessToken (RS256, 15min)
+  → Generate refreshToken (RS256, 7d)
+  → Store refreshToken in DB (RefreshToken model)
+  → Set refreshToken in httpOnly cookie (path: /api/auth)
+  → Return { accessToken, user }
+
+POST /api/auth/refresh
+  → Read cookie refreshToken (fallback: body for Marketplace)
+  → Verify token in DB
+  → Rotate: delete old, issue new
+  → Return { accessToken }
+
+POST /api/auth/logout
+  → Delete refreshToken from DB
+  → Clear cookie
+```
+
+---
+
+## Checkout Flow
+
+```
+1. POST /api/checkout/create-session
+   → Validate cart items (prices from DB, not client)
+   → Apply promo code if provided (atomic usedCount increment)
+   → Create Stripe Checkout session
+   → Return { sessionUrl }
+
+2. Stripe redirects user to payment
+
+3. POST /api/checkout/webhook (Stripe event)
+   → Verify Stripe signature
+   → On checkout.session.completed:
+     → Transaction: check stripeSessionId uniqueness (P2002 = duplicate)
+     → Create Order + OrderItems + OrderEvents
+     → Update ProductVariant stock
+     → Send confirmation email
+```
+
+---
+
+## Pricing Integration
+
+### `pricing/normalizeTcgdexPricing.ts`
+- Fetches card prices from TCGdex API (CardMarket, TCGPlayer)
+- Normalizes price data to internal format
+
+### `pricing/snapshotTcgdexPricing.ts`
+- Captures price snapshots to `CardPriceSnapshot` model
+- Enables price trend visualization
+
+---
+
+## Testing
+
+**Framework:** Vitest 4.0.16
+
+**Test database:** PostgreSQL on port 5434 (separate from dev)
+
+```bash
+npm --prefix server test                              # Run all tests
+npm --prefix server run test:watch                    # Watch mode
+npm --prefix server run test:coverage                 # Coverage report
+npm --prefix server test -- src/__tests__/auth.test.ts  # Single file
+```
+
+**Test files (24) — 376 test cases total:**
+
+| File | Coverage area |
+|------|--------------|
+| `auth.test.ts` | Auth routes (login, register, refresh) |
+| `middleware-auth.test.ts` | JWT middleware |
+| `checkout.test.ts` | Stripe session, webhook idempotence |
+| `admin-orders.test.ts` | Admin order management |
+| `products.test.ts` | Product catalogue |
+| `collection.test.ts` | User collections |
+| `orders.test.ts` | Order history |
+| `trade-cards.test.ts` | Trade card search & details |
+| `routes-reviews.test.ts` | Reviews CRUD |
+| `routes-promo.test.ts` | Promo code logic |
+| `routes-gdpr.test.ts` | GDPR endpoints |
+| `routes-twoFactor.test.ts` | 2FA setup |
+| `routes-users.test.ts` | User profile |
+| `security.test.ts` | Security middleware |
+| `security-extended.test.ts` | Extended security tests |
+| `email-templates.test.ts` | Email rendering |
+| `config.test.ts` | Config validation |
+| `tracking.test.ts` | Tracking HMAC |
+| `utils-audit.test.ts` | Audit logging utility |
+| `utils-auth.test.ts` | JWT generation & token helpers |
+| `utils-date.test.ts` | Date utilities |
+| `validators.test.ts` | Zod/express-validator schemas |
+| `normalizeTcgdexPricing.test.ts` | Pricing normalization |
+| `snapshot.test.ts` | Price snapshots |
+
+---
+
+## Logging
+
+**Winston configuration:**
+- `logs/app-YYYY-MM-DD.log` — All application logs
+- `logs/error-YYYY-MM-DD.log` — Errors only
+- `logs/audit-YYYY-MM-DD.log` — Audit trail (sensitive operations)
+- Console output in development
+
+**Audit events logged:** Login attempts, password changes, 2FA changes, order creation, admin operations, GDPR requests.
+
+---
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|---------|
+| `DATABASE_URL` | PostgreSQL connection string | Yes |
+| `JWT_PRIVATE_KEY` | RS256 private key (PEM) | Yes |
+| `JWT_PUBLIC_KEY` | RS256 public key (PEM) | Yes |
+| `STRIPE_SECRET_KEY` | Stripe API secret | Yes |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret | Yes |
+| `SMTP_HOST` | Email SMTP host | Yes |
+| `SMTP_PORT` | Email SMTP port | Yes |
+| `SMTP_USER` | Email SMTP user | Yes |
+| `SMTP_PASS` | Email SMTP password | Yes |
+| `ORDER_TRACKING_SECRET` | HMAC secret for tracking links | Yes |
+| `FRONTEND_PUBLIC_URL` | Frontend URL (for emails, redirects) | Yes |
+| `NODE_ENV` | `production` or `development` | Yes |
+| `ENABLE_SWAGGER` | Enable Swagger UI at `/api-docs` | No |
+
+---
+
+## API Documentation
+
+Swagger UI available at `http://localhost:8080/api-docs` when `ENABLE_SWAGGER=true`.
+
+Spec generated in `server/src/swagger.ts`.
+
+---
+
+## Database Commands
+
+```bash
+# Generate Prisma client (after schema changes)
+npx --prefix server prisma generate
+
+# Create migration
+npm --prefix server run db:migrate
+
+# Deploy migrations (production)
+npm --prefix server run db:migrate:deploy
+
+# Seed database
+npm --prefix server run seed
+```

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,200 @@
+# Database Documentation — PostgreSQL + Prisma
+
+**Generated:** 2026-03-15
+**ORM:** Prisma 6.15.0
+**Database:** PostgreSQL 17
+**Schema:** `server/prisma/schema.prisma`
+**Migrations:** 9 (since 2024-12-24)
+
+---
+
+## Models Overview
+
+| Model | Purpose | Key Relations |
+|-------|---------|--------------|
+| `User` | Core user account | → UserProfile, Order, TradeOffer, RefreshToken, etc. |
+| `UserProfile` | Extended user info | ← User (1:1) |
+| `Favorite` | Saved cards | ← User |
+| `Order` | E-commerce orders | ← User, → OrderItem, OrderEvent |
+| `OrderEvent` | Order status history | ← Order |
+| `OrderItem` | Line items per order | ← Order, → ProductVariant |
+| `Product` | Product catalogue | → ProductVariant, ProductImage, ProductReview |
+| `ProductImage` | Product photos | ← Product |
+| `ProductVariant` | SKU/pricing/stock | ← Product, → OrderItem |
+| `TradeOffer` | P2P trades | ← User (sender/receiver) |
+| `ContestTicket` | Contest entries | ← User |
+| `RefreshToken` | JWT refresh tokens | ← User |
+| `PasswordResetToken` | Password reset | ← User |
+| `ProductReview` | Ratings & reviews | ← User, ← Product |
+| `PromoCode` | Discount codes | → Order |
+| `UserCollection` | Owned cards | ← User |
+| `StockNotification` | Back-in-stock alerts | ← User, ← ProductVariant |
+| `CardPriceSnapshot` | Market price history | |
+| `SaleTransaction` | Internal sales analytics | |
+
+---
+
+## Key Models Detail
+
+### User
+```prisma
+model User {
+  id                    String    @id @default(cuid())
+  email                 String    @unique
+  password              String    // bcrypt hash
+  role                  String    @default("user") // "user" | "admin"
+  twoFactorEnabled      Boolean   @default(false)
+  twoFactorSecret       String?
+  marketingConsent      Boolean   @default(false)
+  marketingConsentDate  DateTime?
+  deletionRequestedAt   DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  // Relations: profile, orders, favorites, refreshTokens, etc.
+}
+```
+
+### Order
+```prisma
+model Order {
+  id               String      @id @default(cuid())
+  userId           String
+  status           OrderStatus @default(PENDING)
+  fulfillmentStatus FulfillmentStatus @default(UNFULFILLED)
+  stripeSessionId  String?     @unique  // Webhook idempotence
+  total            Decimal
+  carrier          Carrier?
+  trackingNumber   String?
+  shippingAddress  Json        // { name, address, city, zip, country }
+  createdAt        DateTime    @default(now())
+  // Relations: user, items, events
+}
+```
+
+### ProductVariant
+```prisma
+model ProductVariant {
+  id            String  @id @default(cuid())
+  productId     String
+  sku           String  @unique
+  price         Decimal
+  stock         Int     @default(0)
+  stripePriceId String? // Stripe Price object ID
+  condition     String? // "NM", "LP", "MP", "HP", "D"
+  language      String? // "FR", "EN", "JP", etc.
+  // Relations: product, orderItems, stockNotifications
+}
+```
+
+### PromoCode
+```prisma
+model PromoCode {
+  id           String    @id @default(cuid())
+  code         String    @unique
+  type         PromoType // PERCENTAGE | FIXED_AMOUNT
+  value        Decimal
+  usageLimit   Int?
+  usedCount    Int       @default(0)
+  expiresAt    DateTime?
+  active       Boolean   @default(true)
+}
+```
+
+### CardPriceSnapshot
+```prisma
+model CardPriceSnapshot {
+  id        String      @id @default(cuid())
+  cardId    String      // TCGdex card ID
+  market    PriceMarket // CARDMARKET | TCGPLAYER
+  price     Decimal?
+  currency  String
+  snappedAt DateTime    @default(now())
+  @@index([cardId, market, snappedAt])
+}
+```
+
+---
+
+## Enums
+
+### OrderStatus
+`PENDING` | `CONFIRMED` | `PROCESSING` | `SHIPPED` | `DELIVERED` | `CANCELLED` | `REFUNDED`
+
+### FulfillmentStatus
+`UNFULFILLED` | `PARTIAL` | `FULFILLED`
+
+### Carrier
+`COLISSIMO` | `MONDIAL_RELAY` | `CHRONOPOST` | `UPS` | `DHL` | `FEDEX`
+
+### OrderEventType
+`CREATED` | `CONFIRMED` | `PROCESSING` | `SHIPPED` | `DELIVERED` | `CANCELLED` | `REFUNDED` | `NOTE`
+
+### TradeStatus
+`PENDING` | `ACCEPTED` | `REJECTED` | `CANCELLED`
+
+### PromoType
+`PERCENTAGE` | `FIXED_AMOUNT`
+
+### PriceMarket
+`CARDMARKET` | `TCGPLAYER`
+
+---
+
+## Migrations History
+
+| Migration | Date | Description |
+|-----------|------|-------------|
+| `20251224143337_init` | 2024-12-24 | Initial schema |
+| `20260101192245_add_stock_notifications` | 2026-01-01 | StockNotification model |
+| `20260111120000_add_marketing_consent` | 2026-01-11 | GDPR marketing consent fields |
+| `20260210120000_add_sale_transaction` | 2026-02-10 | SaleTransaction model |
+| `20260216120000_add_card_price_snapshots` | 2026-02-16 | CardPriceSnapshot model |
+| `20260311120000_add_stripe_session_id_to_orders` | 2026-03-11 | `Order.stripeSessionId @unique` |
+| `20260312000000_add_password_reset_tokens` | 2026-03-12 | PasswordResetToken model |
+| `20260313000000_add_indexes_orderitem_tradeoffer` | 2026-03-13 | Performance indexes |
+
+---
+
+## Key Patterns
+
+### Idempotence
+- `Order.stripeSessionId @unique` — prevents duplicate orders from repeated Stripe webhooks
+- Webhook handler catches `P2002` (unique constraint violation) gracefully
+
+### Atomic Operations
+- PromoCode `usedCount` incremented with `updateMany` + `usedCount < usageLimit` condition — prevents over-redemption under concurrent load
+
+### Cascade Deletes
+- `User` deletion cascades to all related records (GDPR compliance)
+
+### JSON Fields
+- `Order.shippingAddress` — flexible shipping data
+- `UserProfile.preferences` — extensible user preferences
+- `TradeOffer.offeredCards` / `requestedCards` — card lists as JSON
+
+### Indexes
+- `CardPriceSnapshot`: `[cardId, market, snappedAt]`
+- `OrderItem`: foreign key indexes for join performance
+- `TradeOffer`: status + userId indexes
+
+---
+
+## Prisma Singleton
+
+```typescript
+// server/src/lib/prisma.ts
+// Single PrismaClient instance with exponential retry on connection failure
+// Prevents connection pool exhaustion in serverless/hot-reload scenarios
+```
+
+---
+
+## Database Connection
+
+```bash
+# Dev (docker)
+DATABASE_URL="postgresql://user:pass@localhost:5434/boulevardtcg"
+
+# Production (with PgBouncer)
+DATABASE_URL="postgresql://user:pass@pgbouncer:6432/boulevardtcg?pgbouncer=true"
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,171 @@
+# Deployment Documentation — BoulevardTCG
+
+**Generated:** 2026-03-15
+
+---
+
+## Local Development
+
+### Prerequisites
+- Node.js >= 24.0.0
+- Docker & Docker Compose
+- npm (no yarn/pnpm)
+
+### Quick Start
+
+```bash
+# 1. Start PostgreSQL only
+docker compose up -d postgres
+
+# 2. Setup backend
+cp server/.env.example server/.env
+# Edit server/.env with your values
+npx --prefix server prisma generate
+npm --prefix server run db:migrate
+npm --prefix server run seed
+
+# 3. Start services
+npm run dev:back    # http://localhost:8080
+npm run dev:front   # http://localhost:5173
+```
+
+### Full Docker Stack
+
+```bash
+# Build and start everything
+docker compose up --build
+
+# With Stripe CLI for webhook testing (profile)
+docker compose --profile stripe up --build
+```
+
+---
+
+## Docker Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| `pokecard-frontend` | `./pokecard/Dockerfile` | 3000 | React app via Nginx |
+| `pokecard-backend` | `./server/Dockerfile` | 8080 | Express API |
+| `postgres` | postgres:17-alpine | 5434 | Database |
+| `stripe-cli` | stripe/stripe-cli | — | Webhook forwarding (profile: stripe) |
+
+### Frontend Dockerfile
+- Multi-stage: Node build → Nginx serve
+- `VITE_API_URL` injected at build time as `--build-arg`
+- Nginx config: `pokecard/nginx.conf`
+
+### Backend Dockerfile
+- Node.js 24 Alpine
+- `entrypoint.sh`: runs migrations then starts server
+- RS256 keys injected via environment variables
+
+---
+
+## Production Deployment
+
+### Infrastructure
+
+```
+Internet
+   ↓ HTTPS
+Caddy (TLS termination + reverse proxy)
+   ↓
+Docker network
+   ├── pokecard-frontend (Nginx, port 3000)
+   └── pokecard-backend (Node.js, port 8080)
+          └── PostgreSQL (port 5434)
+```
+
+### Caddy Configuration
+`deployment/Caddyfile` — handles:
+- TLS certificate auto-provisioning (Let's Encrypt)
+- Reverse proxy to frontend/backend
+- HTTP → HTTPS redirect
+
+### Production Environment
+
+Copy `docker-compose.production.example.env` and fill:
+```env
+# Database
+DATABASE_URL=postgresql://user:pass@postgres:5432/boulevardtcg
+
+# JWT Keys (RS256) — inline PEM
+JWT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n..."
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n..."
+
+# Stripe
+STRIPE_SECRET_KEY=sk_live_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Email
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=noreply@example.com
+SMTP_PASS=...
+
+# App
+FRONTEND_PUBLIC_URL=https://boulevardtcg.com
+ORDER_TRACKING_SECRET=<64 char random string>
+NODE_ENV=production
+```
+
+---
+
+## CI/CD
+
+**GitHub Actions:** `.github/workflows/ci.yml`
+
+Pipeline runs on push/PR:
+1. Install dependencies (frontend + backend)
+2. Lint (ESLint)
+3. Type check (TypeScript)
+4. Tests (Vitest)
+
+---
+
+## Post-Deploy Verification
+
+```bash
+# Smoke tests
+node deployment/e2e-smoke.mjs https://your-domain.com
+```
+
+Smoke test checks:
+- API health endpoint
+- Frontend loads
+- Key routes respond
+
+---
+
+## Database Migrations in Production
+
+```bash
+# Deploy pending migrations (no interactive prompts)
+npm --prefix server run db:migrate:deploy
+```
+
+The backend `entrypoint.sh` runs this automatically on container start.
+
+---
+
+## Monitoring
+
+- **Logs:** Winston daily rotation in `server/logs/`
+- **Errors:** `logs/error-YYYY-MM-DD.log`
+- **Audit:** `logs/audit-YYYY-MM-DD.log`
+- **Swagger:** `https://api.domain.com/api-docs` (if `ENABLE_SWAGGER=true`)
+
+---
+
+## Generating JWT Keys (RS256)
+
+```bash
+# Generate keys
+openssl genrsa -out server/keys/jwt_private.pem 2048
+openssl rsa -in server/keys/jwt_private.pem -pubout -out server/keys/jwt_public.pem
+
+# For Docker: inline as env var
+JWT_PRIVATE_KEY=$(cat server/keys/jwt_private.pem | tr '\n' '\\n')
+JWT_PUBLIC_KEY=$(cat server/keys/jwt_public.pem | tr '\n' '\\n')
+```

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,211 @@
+# Frontend Documentation — pokecard/
+
+**Generated:** 2026-03-15
+**Part type:** web
+**Directory:** `pokecard/`
+**Dev port:** 5173
+
+---
+
+## Technology Stack
+
+| Technology | Version | Purpose |
+|------------|---------|---------|
+| React | 19.1.0 | UI framework |
+| React Router | 7.6.2 | Client-side routing |
+| TypeScript | 5.8.3 | Type safety |
+| Vite | 5.4.19 | Build tool & dev server |
+| Three.js | 0.179.1 | 3D card rendering |
+| React Three Fiber | 9.3.0 | Three.js React bindings |
+| @paper-design/shaders-react | 0.0.69 | Holographic shader effects |
+| Framer Motion | 12.12.2 | Animations |
+| Stripe.js | 2.4.0 | Payment integration |
+| Lucide React | latest | Icon library |
+| ESLint | 9.29 | Linting |
+| Prettier | 3.7.4 | Code formatting |
+
+---
+
+## Directory Structure
+
+```
+pokecard/src/
+├── pages/                  # Route-level page components (22)
+├── components/             # Reusable UI components (71)
+│   ├── admin/              # Admin layout
+│   ├── catalogue/          # Product catalogue components (6)
+│   ├── icons/              # SVG icon components (3)
+│   ├── landing/            # Landing page sections (16)
+│   ├── navbar/             # Navigation (1)
+│   └── ui/                 # Generic UI primitives (2)
+│   └── (shared)            # Cross-cutting components (12)
+├── contexts/               # React Context providers (3)
+├── hooks/                  # Custom hooks (2)
+├── utils/                  # Utility functions (3)
+├── styles/                 # Global styles & design tokens
+├── pokeholo-css/           # Card holographic CSS library
+├── assets/                 # Static assets
+├── theme/                  # Theme configuration
+├── api.ts                  # Centralized API client
+├── authContext.tsx          # Auth state & token management
+├── cartContext.tsx          # Shopping cart state
+├── foilMap.ts              # Card foil mapping
+└── shippingMethods.ts      # Shipping method constants
+```
+
+---
+
+## Pages (22)
+
+| Page | Route (inferred) | Purpose |
+|------|-----------------|---------|
+| Home | `/` | Landing page |
+| LoginPage | `/login` | User authentication |
+| RegisterPage | `/register` | User registration |
+| ForgotPasswordPage | `/forgot-password` | Password reset request |
+| ResetPasswordPage | `/reset-password` | Password reset form |
+| ProductsPage | `/products` | Product catalogue |
+| ProductDetail | `/products/:id` | Single product view |
+| CardsPage | `/cards` | Pokémon cards catalogue |
+| AccessoiresPage | `/accessories` | Accessories catalogue |
+| ProtectionsPage | `/protections` | Card protections catalogue |
+| CategorySpecificPage | `/category/:slug` | Category-filtered products |
+| CartPage | `/cart` | Shopping cart |
+| CheckoutSuccess | `/checkout/success` | Post-payment confirmation |
+| OrdersPage | `/orders` | User order history |
+| OrderDetailPage | `/orders/:id` | Order details |
+| OrderTrackingPage | `/tracking` | Order tracking |
+| TradePage | `/trade` | P2P trade marketplace |
+| TradeSetPage | `/trade/set` | Create trade offer |
+| UserProfile | `/profile` | User account settings |
+| HoloCard | `/holo` | 3D card demo/viewer |
+| Concours | `/concours` | Contest page |
+| ContactPage | `/contact` | Contact form |
+| AdminOrdersPage | `/admin/orders` | Admin order management |
+| NewsPage | `/news` | News/blog |
+
+---
+
+## Contexts
+
+### AuthContext (`authContext.tsx`)
+- Stores `user` and `accessToken` in state
+- `accessToken` in `localStorage` (15min expiry)
+- Refresh token in httpOnly cookie — **never** in localStorage or JSON response
+- `credentials: 'include'` on `/api/auth/refresh` and `/api/auth/logout`
+- Auto-refresh before expiry
+
+### CartContext (`cartContext.tsx`)
+- Client-side cart state
+- Items: `{ product, variant, quantity }`
+- Persisted in localStorage
+
+### DarkModeContext (`contexts/`)
+- User theme preference
+- Persisted in localStorage
+
+---
+
+## Key Components
+
+### Catalogue
+| Component | Purpose |
+|-----------|---------|
+| `ProductCard` | Product card with image, price, add-to-cart |
+| `ProductGrid` | Grid layout with virtualization |
+| `ProductListItem` | List layout variant |
+| `FilterBar` | Top filter controls |
+| `FilterSidebar` | Sidebar filters (category, price, etc.) |
+| `ViewToggle` | Grid/list view switcher |
+
+### Landing (16 sections)
+Hero, Benefits, FAQ, and 13 other landing page sections for the home page.
+
+### Shared
+| Component | Purpose |
+|-----------|---------|
+| `ProtectedRoute` | Redirects unauthenticated users |
+| `AdminRoute` | Admin-only route guard |
+| `ErrorBoundary` | React error boundary |
+| `CheckoutAuth` | Auth gate for checkout flow |
+| `CheckoutButton` | Stripe checkout trigger |
+| `NavDropdown` | Navbar dropdown menu |
+| `NotifyModal` | Back-in-stock notification signup |
+| `ScrollProtectedCard` | Wraps 3D card during scroll |
+| `TwoFactorSettings` | 2FA management UI |
+
+---
+
+## API Client (`api.ts`)
+- Centralized axios/fetch wrapper
+- Injects `Authorization: Bearer <token>` on authenticated requests
+- Handles 401 → auto-refresh token flow
+- Base URL from `import.meta.env.VITE_API_URL`
+
+---
+
+## 3D Card System
+
+The holographic card effect uses:
+- **Three.js + React Three Fiber** for 3D rendering
+- **@paper-design/shaders-react** for holographic shaders
+- **pokeholo-css/** — CSS library for card foil effects
+- **foilMap.ts** — Maps card IDs to foil textures
+- **ScrollProtectedCard** — Pauses 3D rendering during scroll for performance
+
+---
+
+## State Management
+
+No external state library (Redux/Zustand). Uses:
+1. React Context API for global state (auth, cart, dark mode)
+2. Local component state (`useState`, `useReducer`) for UI state
+3. `localStorage` for persistence (token, cart, preferences)
+
+---
+
+## Routing
+
+React Router v7 with:
+- `ProtectedRoute` wrapper for authenticated pages
+- `AdminRoute` wrapper for admin pages
+- Client-side navigation (SPA)
+
+---
+
+## Build & Dev
+
+```bash
+# Development (hot reload, port 5173)
+npm --prefix pokecard run dev
+
+# Production build
+npm --prefix pokecard run build
+
+# Lint
+npm --prefix pokecard run lint
+```
+
+**Vite config:** `pokecard/vite.config.ts`
+- API proxy to backend in development
+- TypeScript path aliases
+
+---
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|---------|
+| `VITE_API_URL` | Backend API base URL | Yes |
+
+---
+
+## Key Utilities
+
+| File | Purpose |
+|------|---------|
+| `utils/filters.ts` | Product filtering logic |
+| `utils/productMatching.ts` | Product search/match helpers |
+| `utils/security.ts` | Input sanitization helpers |
+| `shippingMethods.ts` | Shipping option constants (mirrors server config) |
+| `foilMap.ts` | Card ID → foil texture mapping |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,88 @@
+# BoulevardTCG — Documentation Index
+
+**Generated:** 2026-03-15
+**Scan level:** Deep
+**Project:** pok-card
+**Parts:** Frontend (`pokecard/`), Backend (`server/`)
+
+---
+
+## Quick Reference
+
+| Topic | File | Description |
+|-------|------|-------------|
+| Architecture | [architecture.md](./architecture.md) | System design, deployment, key decisions |
+| Frontend | [frontend.md](./frontend.md) | React app, components, contexts, routing |
+| Backend | [backend.md](./backend.md) | Express API, middleware, services, tests |
+| Database | [database.md](./database.md) | Prisma schema, models, migrations |
+| API Reference | [api.md](./api.md) | All endpoints, request/response format |
+| Security | [security.md](./security.md) | Auth, rate limiting, GDPR, audit log |
+| Deployment | [deployment.md](./deployment.md) | Docker, production setup, CI/CD |
+
+---
+
+## Project Summary
+
+**BoulevardTCG** is a TCG e-commerce platform with shop, marketplace, and trading features.
+
+- **Frontend:** React 19 + TypeScript + Vite — 22 pages, 71 components, holographic 3D card effects
+- **Backend:** Express + TypeScript + Prisma — 14 route modules, 20 test files
+- **Database:** PostgreSQL 17 — 19 models, 9 migrations
+- **Payments:** Stripe Checkout with idempotent webhook-based order creation
+- **Auth:** JWT RS256 + optional 2FA (TOTP)
+- **Node version:** >= 24.0.0
+
+---
+
+## Development Quick Start
+
+```bash
+# Start PostgreSQL
+docker compose up -d postgres
+
+# Backend (port 8080)
+npm --prefix server run dev
+
+# Frontend (port 5173)
+npm --prefix pokecard run dev
+
+# Run tests
+npm --prefix server test
+```
+
+---
+
+## Key Workflows
+
+### Checkout
+`POST /api/checkout/create-session` → Stripe → Webhook `checkout.session.completed` → Order in DB → Email
+
+### Auth
+`POST /api/auth/login` → `{ accessToken }` + refresh cookie → Auto-refresh before expiry
+
+### Order Fulfillment
+Admin: `PATCH /api/admin/orders/:id` with carrier + tracking → Shipping email sent
+
+---
+
+## Environment Files
+
+| File | Purpose |
+|------|---------|
+| `server/.env` | Backend secrets (copy from `server/env.example`) |
+| `pokecard/.env` | Frontend build vars (`VITE_API_URL`) |
+| `docker-compose.production.example.env` | Production Docker env template |
+
+---
+
+## Additional Docs in Repo
+
+| File | Content |
+|------|---------|
+| `CLAUDE.md` | Claude Code project instructions |
+| `DEV_LOCAL.md` | Local development setup guide |
+| `BACKEND_SECURITY_ROADMAP.md` | Security audit roadmap |
+| `server/BACKEND_EXPLAINED.md` | Backend architecture details |
+| `server/FLUX_DIAGRAMS.md` | Flow diagrams |
+| `server/CONTACT_FLOW.md` | Contact form flow |
+| `pokecard/FEATURES.md` | Frontend features list |

--- a/docs/project-scan-report.json
+++ b/docs/project-scan-report.json
@@ -1,0 +1,35 @@
+{
+  "version": "1.0",
+  "mode": "initial_scan",
+  "scan_level": "deep",
+  "last_updated": "2026-03-15T00:00:00.000Z",
+  "current_step": "completed",
+  "completed_steps": ["0.5", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+  "total_steps": 12,
+  "project_classification": {
+    "type": "multi-part",
+    "structure": "monorepo",
+    "parts": [
+      {
+        "name": "frontend",
+        "directory": "pokecard/",
+        "project_type_id": "web"
+      },
+      {
+        "name": "backend",
+        "directory": "server/",
+        "project_type_id": "backend"
+      }
+    ]
+  },
+  "generated_files": [
+    "docs/index.md",
+    "docs/architecture.md",
+    "docs/frontend.md",
+    "docs/backend.md",
+    "docs/database.md",
+    "docs/api.md",
+    "docs/security.md",
+    "docs/deployment.md"
+  ]
+}

--- a/docs/prompt-migration-boxtal-tamp.md
+++ b/docs/prompt-migration-boxtal-tamp.md
@@ -1,0 +1,114 @@
+# Prompt : migration livraison Mondial Relay → Boxtal API v3 (projet tamp)
+
+> Copier-coller tout ce qui suit comme premier message d'une session Claude Code ouverte dans le projet tamp.
+
+---
+
+Je veux remplacer entièrement l'intégration actuelle de l'API Mondial Relay par **Boxtal API v3** (agrégateur multi-transporteurs). J'ai déjà fait cette migration sur mon autre projet (BoulevardTCG) : voici toutes les connaissances acquises et vérifiées en conditions réelles — appuie-toi dessus pour aller vite et éviter les pièges déjà rencontrés. Ne me redemande pas les décisions de périmètre listées ci-dessous.
+
+## Décisions de périmètre (déjà tranchées, identiques à BoulevardTCG)
+
+- **Frais de port : prix fixes** définis par la boutique — pas de cotation dynamique Boxtal au checkout.
+- **Le client choisit son point relais au checkout** : sélecteur alimenté par l'API Boxtal via un **proxy backend rate-limité** (les clés API ne transitent jamais côté front). Choix obligatoire si le mode de livraison est en relais (validation front ET back).
+- **Étiquettes générées depuis l'admin** via l'API ; la saisie manuelle (transporteur + n° de suivi) reste disponible en secours.
+- **Cycle d'états réaliste** :
+  - étiquette créée → commande « **En préparation** » (pas d'email)
+  - premier scan transporteur (webhook ou resync) → « **Expédiée** » + email client avec n° de suivi
+  - livraison → « **Livrée** » + email de confirmation
+  - L'état « En préparation » doit être visible côté client (badge + étape de timeline) ET côté admin.
+- **Suivi automatique** par webhooks Boxtal + bouton « Resync » dans l'admin (récupère suivi/étiquette et applique les transitions — utile en local sans URL publique).
+- L'ancienne intégration Mondial Relay est **supprimée** une fois Boxtal fonctionnel (pas de double système).
+
+## Spec API Boxtal v3 (vérifiée en réel le 15/07/2026)
+
+- **Environnements** : test `https://api.boxtal.build` (compte sandbox séparé, rien n'est facturé), prod `https://api.boxtal.com`. Les clés test/prod ne sont pas interchangeables.
+- **Auth** : `Authorization: Basic base64(accessKey:secretKey)` acceptée sur **tous** les endpoints — inutile de gérer un token Bearer.
+- **Endpoints** :
+  - `GET /shipping/v3.1/content-category?language=fr` — catégories de contenu (cartes/produits culturels = `content:v1:80100`)
+  - `GET /shipping/v3.2/parcel-point-by-shipping-offer?operationType=ARRIVAL&shippingOfferCode=<code>&postalCode=<cp>&city=<ville>&countryIsoCode=FR` — recherche de points relais (params optionnels `street`, `number`)
+  - `POST /shipping/v3.1/shipping-order` — création d'expédition
+  - `GET /shipping/v3.1/shipping-order/{id}` — détail (status, prix HT, dates)
+  - `GET /shipping/v3.1/shipping-order/{id}/tracking` — suivi
+  - `GET /shipping/v3.1/shipping-order/{id}/shipping-document` — documents (étiquette)
+  - `DELETE /shipping/v3.1/shipping-order/{id}` — annulation (422 si déjà prise en charge)
+  - `POST /shipping/v3.1/subscription` — souscription webhook `{ eventType: "DOCUMENT_CREATED"|"TRACKING_CHANGED", callbackUrl, webhookSecret }`
+
+### Pièges vérifiés en réel (à ne pas redécouvrir)
+
+1. La réponse parcel-point imbrique chaque point sous la clé **`parcelPoint` (camelCase)** — les libs de référence publiques utilisent `parcelpoint` en minuscules. Accepter les deux graphies dans le normaliseur, sinon liste vide silencieuse. Structure : `{ content: [{ parcelPoint: { code, name, location: { street, number, city, postalCode, countryIsoCode, position: { latitude, longitude } }, openingDays: { MONDAY: [{ openingTime, closingTime }] | null, ... }, compatibleNetworks: [...] }, distanceFromSearchLocation: <mètres> }] }`.
+2. Suivi et étiquette renvoient **422** tant qu'ils ne sont pas générés (systématique juste après création) → retourner `null`, compléter plus tard via webhook ou resync. Ne pas traiter comme une erreur.
+3. **Webhooks** : header `x-bxt-signature` = HMAC SHA256 du **corps brut** avec le `webhookSecret` de la souscription — l'encodage n'est pas documenté, accepter **hex ET base64** (comparaison timing-safe). Répondre en **moins de 2 s** sinon rejeu (10 tentatives sur 24 h). Répondre 200 même pour une commande inconnue (éviter les rejeux). Événements : `TRACKING_CHANGED` (payload.trackings: [{ status, trackingNumber, packageTrackingUrl }]) et `DOCUMENT_CREATED` (payload.documents: [{ url, type: "LABEL", format }]) + champs racine `shippingOrderId` et `shipmentExternalId`.
+4. Le corps brut est indispensable pour la signature → monter la route webhook **avant** le body-parser JSON global (comme un webhook Stripe).
+5. **Statuts de suivi** : `ANNOUNCED` (étiquette créée — ne rien faire), `SHIPPED`/`IN_TRANSIT`/`OUT_FOR_DELIVERY`/`FAILED_ATTEMPT`/`REACHED_DELIVERY_PICKUP_POINT` → expédiée, `DELIVERED` → livrée, `RETURNED`/`EXCEPTION` → logger. Statuts de la commande d'expédition : `PENDING` → `REQUESTED` → `CONFIRMED` (étiquette dispo) / `CANCELLED`.
+6. **Codes d'offre** (validés sur l'env de test) : relais Mondial Relay = `MONR-CpourToi`, domicile Colissimo = `POFR-ColissimoAccess` (existe aussi `POFR-ColissimoExpert`). Le préfixe avant le tiret identifie l'opérateur : MONR, POFR, CHRP (Chronopost), UPSE, DHLE, FEDX — utile pour mapper vers un enum transporteur interne. Un code invalide → 400 `ValidationException.ValidShippingOfferCode`.
+7. L'URL de l'étiquette est **signée et expire après 7 jours** — la re-récupérer via `/shipping-document` si besoin (bouton resync).
+8. Le prix affiché par Boxtal (`deliveryPriceExclTax`) est ce que paie la boutique (HT, tarif négocié) — rien à voir avec les frais de port facturés au client. Ne pas essayer de les faire correspondre.
+
+### Payload de création d'expédition (structure exacte)
+
+```json
+{
+  "shippingOfferCode": "MONR-CpourToi",
+  "labelType": "PDF_A4",
+  "shipment": {
+    "externalId": "<id interne de la commande — sert de fallback de lookup webhook>",
+    "content": { "id": "content:v1:80100", "description": "Description du contenu" },
+    "fromAddress": {
+      "type": "BUSINESS",
+      "contact": { "firstName": "...", "lastName": "...", "email": "...", "phone": "+33612345678", "company": "..." },
+      "location": { "street": "rue des Cartes", "number": "10", "postalCode": "75001", "city": "Paris", "countryIsoCode": "FR" }
+    },
+    "toAddress": { "type": "RESIDENTIAL", "contact": { "...": "phone OBLIGATOIRE, format +33..." }, "location": { "...": "..." } },
+    "returnAddress": "<copie de fromAddress>",
+    "packages": [{
+      "type": "PARCEL",
+      "weight": 0.3,
+      "length": 24, "width": 18, "height": 8,
+      "value": { "value": 45.0, "currency": "EUR" },
+      "content": { "id": "content:v1:80100", "description": "..." },
+      "externalId": "<id commande>"
+    }],
+    "pickupPointCode": "<code relais — OBLIGATOIRE pour une offre relais, omis pour domicile>"
+  }
+}
+```
+
+Contraintes : poids en **kg** (précision au gramme), dimensions en **cm entiers**, valeur en euros ; `Contact` exige firstName/lastName/email/**phone international** (normaliser `06...` → `+336...`) ; `Location` exige street/city/countryIsoCode, le numéro de voie va dans `number` (splitter « 12 rue X »). Réponse : `{ content: { id: "2440...FR", status: "PENDING" } }`.
+
+## Marche à suivre
+
+1. **Explore d'abord** le code existant de tamp : où vit l'intégration Mondial Relay actuelle (config, service/appels API, modèle de commande en DB, checkout, sélecteur de relais front, admin expédition, emails, webhooks éventuels). Dresse la liste des points de contact avant d'écrire du code, et présente-moi ton plan d'intégration adapté au stack de CE projet avant d'implémenter.
+2. Reproduis le découpage qui a fait ses preuves sur BoulevardTCG :
+   - **config boxtal** : lecture env → objet config, `null` si clés absentes (= fonctionnalité désactivée proprement, l'app doit démarrer sans les clés)
+   - **service boxtal** : client HTTP (timeout ~15 s) + normalisations défensives + mappings transporteur/statuts
+   - **route publique** de recherche de points relais (proxy, rate-limitée, validation des params)
+   - **endpoint admin** de création d'étiquette, **idempotent** : persister l'id Boxtal immédiatement après création ; si l'expédition existe déjà → resynchronisation (suivi + étiquette + transitions) au lieu d'une double étiquette
+   - **handler webhook** (vérif signature, TRACKING_CHANGED, DOCUMENT_CREATED)
+   - **service de transitions d'état partagé** webhook/resync, idempotent (pas de double transition ni double email), qui déclenche les emails client
+3. **DB** : ajouter sur la commande `boxtalShippingOrderId` (unique — lookup webhook), `labelUrl`, `pickupPointCode`, `pickupPoint` (json : code, name, network, adresse). Migration selon les conventions du projet.
+4. **Front** : sélecteur de point relais (recherche CP/ville, liste nom + adresse + distance + horaires, sélection obligatoire si mode relais, conservé dans le brouillon de checkout s'il y en a un) ; affichage du relais choisi sur les pages commande client et admin ; boutons admin « Expédier via Boxtal » / « Resync » + lien étiquette PDF ; état « En préparation » visible client et admin (badge + étape de timeline).
+5. **Emails** : l'email d'expédition part au passage réel en « expédiée » (premier scan transporteur), pas à la création d'étiquette ; inclure le point relais (nom + adresse + rappel pièce d'identité).
+6. Supprime l'ancienne intégration Mondial Relay (code, config, env) une fois la nouvelle vérifiée.
+
+## Variables d'environnement à prévoir (mêmes noms que BoulevardTCG)
+
+```
+BOXTAL_ACCESS_KEY / BOXTAL_SECRET_KEY        # je te les fournirai — mets des placeholders et demande-les-moi
+BOXTAL_API_BASE_URL                          # https://api.boxtal.build (test) puis https://api.boxtal.com (prod)
+BOXTAL_SHIPPING_OFFER_CODE_RELAY             # ex MONR-CpourToi
+BOXTAL_SHIPPING_OFFER_CODE_HOME              # ex POFR-ColissimoAccess
+BOXTAL_SHIPPER_COMPANY / _FIRST_NAME / _LAST_NAME / _EMAIL / _PHONE / _ADDRESS / _POSTAL_CODE / _CITY / _COUNTRY
+BOXTAL_PACKAGE_BASE_WEIGHT_GRAMS / _ITEM_WEIGHT_GRAMS / _LENGTH_CM / _WIDTH_CM / _HEIGHT_CM
+BOXTAL_CONTENT_CATEGORY_ID / _DESCRIPTION    # défaut content:v1:80100 si produits culturels/cartes
+BOXTAL_LABEL_TYPE                            # PDF_A4 ou PDF_10x15
+BOXTAL_WEBHOOK_SECRET                        # choisi par nous à la souscription des webhooks
+```
+
+## Validation attendue avant de me dire « c'est fini »
+
+- **Tests unitaires du service** avec fetch mocké sur les **vraies formes de réponse** ci-dessus (y compris `parcelPoint` camelCase, `openingDays` à null, 422 suivi/étiquette).
+- **Tests d'intégration** : checkout relais sans point relais → 400 ; point relais au format invalide → 400 ; webhook signature invalide → 401 ; webhook commande inconnue → 200 ; transitions PREPARING → SHIPPED → DELIVERED idempotentes ; endpoint admin création → « en préparation » (pas « expédiée ») puis resync → « expédiée ».
+- **Script smoke test rejouable** contre l'environnement de test (recherche relais → création d'expédition → suivi/étiquette → annulation), qui **refuse de tourner contre la prod** sans un flag explicite `--allow-prod`.
+- Lint + typecheck + suite de tests complète du projet au vert.
+
+Les clés de test Boxtal se créent sur https://redirect.boxtal.build/iam/app-redirect/register?app=developer&profile=default&language=fr (compte sandbox gratuit → Applications → créer une app API v3 → paire access key/secret key). Je te donnerai les clés quand tu en auras besoin — ne bloque pas dessus pour commencer l'exploration et l'implémentation.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,131 @@
+# Security Documentation — BoulevardTCG
+
+**Generated:** 2026-03-15
+**Last audit:** fix/audit-p1 (2026-03-15)
+
+---
+
+## Security Layers
+
+### HTTP Layer (Helmet)
+- Strict-Transport-Security
+- X-Content-Type-Options: nosniff
+- X-Frame-Options: DENY
+- Content-Security-Policy
+- Referrer-Policy
+
+### CORS
+- Whitelist: `FRONTEND_PUBLIC_URL` only
+- `credentials: true` (cookies)
+- Specific allowed methods/headers
+
+### Rate Limiting
+| Limiter | Limit | Window | Applied to |
+|---------|-------|--------|-----------|
+| General | 100 req | 15 min | All `/api/*` |
+| Auth | 10 req | 15 min | `/api/auth/*` |
+| 2FA | 5 req | 15 min | `/api/auth/2fa` (per email) |
+
+---
+
+## Authentication Security
+
+### JWT (RS256 asymmetric)
+- Private key signs tokens — stored in `server/keys/jwt_private.pem` (git-ignored)
+- Public key verifies — can be distributed to microservices
+- Access token: 15min expiry, `localStorage`
+- Refresh token: 7d expiry, httpOnly cookie (`path: /api/auth`, `SameSite: Strict`)
+
+### Refresh Token Security
+- Stored hashed in DB (`RefreshToken` model)
+- Rotated on each use (old invalidated, new issued)
+- **Never** sent in JSON response body (except Marketplace fallback via body)
+- **Never** stored in `localStorage` on frontend
+
+### 2FA (TOTP)
+- OTPAuth library, TOTP standard
+- Setup requires verification before activation
+- 5 attempts / 15 min rate limit (prevents brute-force)
+- Secret stored encrypted in `User.twoFactorSecret`
+
+---
+
+## Payment Security
+
+### Stripe
+- All prices validated server-side (client sends `variantId`, not price)
+- Webhook signature verified via `STRIPE_WEBHOOK_SECRET`
+- Order creation in DB transaction with `stripeSessionId @unique`
+- P2002 (duplicate key) caught → idempotent: no duplicate orders
+
+---
+
+## Promo Code Security
+
+- `usedCount` incremented atomically: `updateMany({ where: { id, usedCount: { lt: usageLimit } } })`
+- Prevents over-redemption under concurrent requests
+- Expiry date checked server-side
+
+---
+
+## Password Security
+
+- bcrypt hashing (cost factor: default 10+)
+- Password reset tokens: time-limited, single-use (`PasswordResetToken` model)
+- Reset link sent via email only
+
+---
+
+## Contact Form
+
+- Honeypot field to catch bots
+- Rate limited
+- Input sanitized
+
+---
+
+## GDPR Compliance
+
+- Marketing consent tracked with timestamp (`marketingConsent`, `marketingConsentDate`)
+- Data export endpoint (`POST /api/gdpr/export`)
+- Account deletion request (`POST /api/gdpr/delete`) → `deletionRequestedAt` set, processed by admin
+- Cascade deletes on User removal
+
+---
+
+## Audit Logging
+
+All sensitive operations are logged to `logs/audit-YYYY-MM-DD.log`:
+- Login attempts (success/failure)
+- Password changes
+- 2FA enable/disable
+- Order creation
+- Admin operations
+- GDPR requests
+
+---
+
+## Security Roadmap
+
+See `BACKEND_SECURITY_ROADMAP.md` for planned improvements.
+
+**Completed (fix/audit-p0, fix/audit-p1):**
+- C1: Removed localStorage refreshToken on frontend
+- H1: 2FA rate limiting
+- H3: Atomic promo code increment
+- H4: Stripe webhook idempotence
+- Prisma singleton (prevent connection exhaustion)
+- Error logging with tracking
+- DB performance indexes
+
+---
+
+## Security Checklist for New Features
+
+- [ ] All user input validated (express-validator or Zod)
+- [ ] Prices/amounts always read from DB, never trusted from client
+- [ ] New admin routes use `requireAdmin` middleware
+- [ ] New auth routes have appropriate rate limits
+- [ ] Sensitive operations logged via `utils/audit.ts`
+- [ ] File uploads (Multer) have type/size restrictions
+- [ ] No secrets in logs (passwords, tokens, keys)

--- a/pokecard/src/AdminOrdersPage.tsx
+++ b/pokecard/src/AdminOrdersPage.tsx
@@ -98,6 +98,15 @@ interface Order {
   deliveredAt?: string | null;
   shippingMethod?: string | null;
   shippingCost?: number | null;
+  boxtalShippingOrderId?: string | null;
+  labelUrl?: string | null;
+  pickupPointCode?: string | null;
+  pickupPoint?: {
+    name?: string | null;
+    line1?: string | null;
+    postalCode?: string | null;
+    city?: string | null;
+  } | null;
   shippingAddress?: {
     name?: string | null;
     address?: {
@@ -147,6 +156,7 @@ export function AdminOrdersPage() {
     note: string;
   }>({ orderId: null, carrier: 'COLISSIMO', trackingNumber: '', note: '' });
   const [shippingLoadingId, setShippingLoadingId] = useState<string | null>(null);
+  const [boxtalLoadingId, setBoxtalLoadingId] = useState<string | null>(null);
   const [deliveringId, setDeliveringId] = useState<string | null>(null);
   const { user, token, isLoading: authLoading } = useAuth();
   const navigate = useNavigate();
@@ -241,6 +251,31 @@ export function AdminOrdersPage() {
       alert(err.message || 'Erreur expédition');
     } finally {
       setShippingLoadingId(null);
+    }
+  }
+
+  async function shipViaBoxtal(orderId: string) {
+    if (!token) return;
+    setBoxtalLoadingId(orderId);
+    try {
+      const response = await fetch(`${API_BASE}/admin/orders/${orderId}/boxtal-shipment`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.error || "Erreur lors de la création de l'expédition Boxtal");
+      }
+      const updated = data.order as Order;
+      setOrders((prev) => prev.map((o) => (o.id === orderId ? { ...o, ...updated } : o)));
+    } catch (err: Error) {
+      alert(err.message || 'Erreur expédition Boxtal');
+    } finally {
+      setBoxtalLoadingId(null);
     }
   }
 
@@ -436,6 +471,12 @@ export function AdminOrdersPage() {
                           <div className={styles.shippingLine}>
                             {order.shippingAddress.address?.country || ''}
                           </div>
+                          {order.pickupPoint && (
+                            <div className={styles.shippingLine}>
+                              <strong>Relais :</strong> {order.pickupPoint.name}
+                              {order.pickupPoint.city ? ` (${order.pickupPoint.city})` : ''}
+                            </div>
+                          )}
                         </div>
                       ) : (
                         <span className={styles.muted}>—</span>
@@ -445,9 +486,16 @@ export function AdminOrdersPage() {
                       <span className={styles.date}>{formatDate(order.createdAt)}</span>
                     </td>
                     <td>
-                      <span className={`${styles.statusBadge} ${styles[status.className]}`}>
-                        {status.label}
-                      </span>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        <span className={`${styles.statusBadge} ${styles[status.className]}`}>
+                          {status.label}
+                        </span>
+                        {order.fulfillmentStatus === 'PREPARING' && (
+                          <span className={`${styles.statusBadge} ${styles.warning}`}>
+                            En préparation
+                          </span>
+                        )}
+                      </div>
                     </td>
                     <td>
                       <div className={styles.actionsColumn}>
@@ -469,6 +517,22 @@ export function AdminOrdersPage() {
 
                         <div className={styles.actionsRow}>
                           <button
+                            className={styles.primaryButton}
+                            disabled={boxtalLoadingId === order.id}
+                            onClick={() => shipViaBoxtal(order.id)}
+                            title={
+                              order.boxtalShippingOrderId
+                                ? 'Resynchroniser le suivi et l’étiquette depuis Boxtal'
+                                : 'Créer l’étiquette Boxtal et notifier le client'
+                            }
+                          >
+                            {boxtalLoadingId === order.id
+                              ? 'Boxtal…'
+                              : order.boxtalShippingOrderId
+                                ? 'Resync Boxtal'
+                                : 'Expédier via Boxtal'}
+                          </button>
+                          <button
                             className={styles.secondaryButton}
                             onClick={() =>
                               setShippingDraft({
@@ -479,7 +543,7 @@ export function AdminOrdersPage() {
                               })
                             }
                           >
-                            Expédier
+                            Saisie manuelle
                           </button>
                           <button
                             className={styles.ghostButton}
@@ -561,6 +625,16 @@ export function AdminOrdersPage() {
                             rel="noreferrer"
                           >
                             Suivi transporteur
+                          </a>
+                        )}
+                        {order.labelUrl && (
+                          <a
+                            className={styles.trackingLink}
+                            href={order.labelUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Étiquette PDF
                           </a>
                         )}
                       </div>

--- a/pokecard/src/CartPage.tsx
+++ b/pokecard/src/CartPage.tsx
@@ -11,8 +11,11 @@ import {
   validatePromoCode,
   getImageUrl,
   safeParse,
+  type ParcelPoint,
+  type PickupPointPayload,
 } from './api';
 import { getEnabledShippingMethods, findShippingMethod } from './shippingMethods';
+import { ParcelPointSelector } from './components/ParcelPointSelector';
 import type { CartItem } from './cartContext';
 
 // Types pour le draft de checkout
@@ -29,6 +32,7 @@ type CheckoutDraft = {
     phone: string;
   };
   shippingMethodCode: string;
+  pickupPoint?: ParcelPoint | null;
   createdAt: number;
 };
 
@@ -65,6 +69,7 @@ export function CartPage() {
   const [shippingMethodCode, setShippingMethodCode] = useState(
     enabledShippingMethods[0]?.code ?? 'MONDIAL_RELAY'
   );
+  const [selectedPickupPoint, setSelectedPickupPoint] = useState<ParcelPoint | null>(null);
 
   // Refs pour l'auto-checkout (une seule exécution)
   const autoCheckoutRanRef = useRef(false);
@@ -120,6 +125,9 @@ export function CartPage() {
     }
     setShipping(draft.shipping);
     setShippingMethodCode(draft.shippingMethodCode);
+    if (draft.pickupPoint) {
+      setSelectedPickupPoint(draft.pickupPoint);
+    }
   }, []);
 
   // Rafraîchir le stock des articles du panier
@@ -212,6 +220,7 @@ export function CartPage() {
       country: string;
       phone?: string;
     };
+    pickupPointCode?: string;
   };
 
   function buildCheckoutSignature(args: CheckoutSignatureArgs) {
@@ -221,6 +230,7 @@ export function CartPage() {
       promoCode: args.promoCode || null,
       shippingMethodCode: args.shippingMethodCode || null,
       shipping: args.shipping || null,
+      pickupPointCode: args.pickupPointCode || null,
     });
   }
 
@@ -271,6 +281,11 @@ export function CartPage() {
       return;
     }
 
+    if (selectedShippingMethod.requiresPickupPoint && !selectedPickupPoint) {
+      setShippingError('Veuillez choisir un point relais pour la livraison.');
+      return;
+    }
+
     setEmailError('');
     setShippingError('');
     setLoading(true);
@@ -307,11 +322,31 @@ export function CartPage() {
       // Assurer que promoCode est undefined quand vide (pas '')
       const stablePromoCode = appliedPromo && appliedPromo.trim() ? appliedPromo : undefined;
 
+      // Point relais choisi (uniquement pour les modes de livraison en relais)
+      const pickupPointPayload: PickupPointPayload | undefined =
+        selectedShippingMethod.requiresPickupPoint && selectedPickupPoint
+          ? {
+              code: selectedPickupPoint.code,
+              name: selectedPickupPoint.name,
+              network: selectedPickupPoint.networks?.[0],
+              address: {
+                line1:
+                  [selectedPickupPoint.address.number, selectedPickupPoint.address.street]
+                    .filter(Boolean)
+                    .join(' ') || undefined,
+                postalCode: selectedPickupPoint.address.postalCode,
+                city: selectedPickupPoint.address.city,
+                country: selectedPickupPoint.address.country,
+              },
+            }
+          : undefined;
+
       const signature = buildCheckoutSignature({
         items,
         promoCode: stablePromoCode,
         shippingMethodCode: stableShippingMethodCode,
         shipping: shippingMapped,
+        pickupPointCode: pickupPointPayload?.code,
       });
       const idempotencyKey = getOrCreateIdempotencyKey(signature);
 
@@ -321,7 +356,8 @@ export function CartPage() {
         stablePromoCode,
         shippingMapped,
         stableShippingMethodCode,
-        idempotencyKey
+        idempotencyKey,
+        pickupPointPayload
       );
 
       if (url) {
@@ -360,6 +396,7 @@ export function CartPage() {
           promoCode: appliedPromo,
           shipping,
           shippingMethodCode,
+          pickupPoint: selectedPickupPoint,
           createdAt: Date.now(),
         };
 
@@ -411,6 +448,7 @@ export function CartPage() {
         promoCode: appliedPromo,
         shipping,
         shippingMethodCode,
+        pickupPoint: selectedPickupPoint,
         createdAt: Date.now(),
       };
       sessionStorage.setItem('checkoutIntent', JSON.stringify({ v: 1, createdAt: Date.now() }));
@@ -608,6 +646,15 @@ export function CartPage() {
                     </label>
                   ))}
                 </div>
+
+                {selectedShippingMethod?.requiresPickupPoint && (
+                  <ParcelPointSelector
+                    defaultPostalCode={shipping.postalCode}
+                    defaultCity={shipping.city}
+                    selected={selectedPickupPoint}
+                    onSelect={setSelectedPickupPoint}
+                  />
+                )}
               </div>
 
               <div className={styles.summaryDetails}>

--- a/pokecard/src/OrderDetailPage.tsx
+++ b/pokecard/src/OrderDetailPage.tsx
@@ -5,6 +5,7 @@ import { API_BASE, getImageUrl } from './api';
 import styles from './OrderDetailPage.module.css';
 import {
   Package,
+  PackageOpen,
   Truck,
   CheckCircle,
   XCircle,
@@ -15,6 +16,7 @@ import {
   Calendar,
   Link as LinkIcon,
 } from 'lucide-react';
+import { getOrderDisplayStatus, ORDER_STATUS_TIMELINE } from './orderStatus';
 
 interface OrderItem {
   id: string;
@@ -34,6 +36,12 @@ interface Order {
   carrier?: string | null;
   trackingNumber?: string | null;
   trackingUrl?: string | null;
+  pickupPoint?: {
+    name?: string | null;
+    line1?: string | null;
+    postalCode?: string | null;
+    city?: string | null;
+  } | null;
   totalCents: number;
   currency: string;
   paymentMethod?: string;
@@ -77,6 +85,12 @@ const statusConfig = {
     color: '#3b82f6',
     bgColor: 'rgba(59, 130, 246, 0.1)',
   },
+  PREPARING: {
+    label: 'En préparation',
+    icon: PackageOpen,
+    color: '#f59e0b',
+    bgColor: 'rgba(245, 158, 11, 0.1)',
+  },
   SHIPPED: { label: 'Expédiée', icon: Truck, color: '#8b5cf6', bgColor: 'rgba(139, 92, 246, 0.1)' },
   DELIVERED: {
     label: 'Livrée',
@@ -98,7 +112,7 @@ const statusConfig = {
   },
 };
 
-const statusTimeline = ['PENDING', 'CONFIRMED', 'SHIPPED', 'DELIVERED'];
+const statusTimeline = ORDER_STATUS_TIMELINE;
 
 export function OrderDetailPage() {
   const { orderId } = useParams<{ orderId: string }>();
@@ -161,7 +175,7 @@ export function OrderDetailPage() {
     });
   };
 
-  const getStatusIndex = (status: string) => {
+  const getStatusIndex = (status: (typeof statusTimeline)[number]) => {
     return statusTimeline.indexOf(status);
   };
 
@@ -194,8 +208,9 @@ export function OrderDetailPage() {
     );
   }
 
-  const StatusIcon = statusConfig[order.status].icon;
-  const currentStatusIndex = getStatusIndex(order.status);
+  const displayStatus = getOrderDisplayStatus(order.status, order.fulfillmentStatus);
+  const StatusIcon = statusConfig[displayStatus].icon;
+  const currentStatusIndex = getStatusIndex(displayStatus);
   const isCancelled = order.status === 'CANCELLED' || order.status === 'REFUNDED';
   const isShipped = order.fulfillmentStatus === 'SHIPPED';
 
@@ -219,12 +234,12 @@ export function OrderDetailPage() {
             <div
               className={styles.statusBadge}
               style={{
-                color: statusConfig[order.status].color,
-                backgroundColor: statusConfig[order.status].bgColor,
+                color: statusConfig[displayStatus].color,
+                backgroundColor: statusConfig[displayStatus].bgColor,
               }}
             >
               <StatusIcon size={18} />
-              {statusConfig[order.status].label}
+              {statusConfig[displayStatus].label}
             </div>
           </div>
         </div>
@@ -372,6 +387,27 @@ export function OrderDetailPage() {
                 <p className={styles.infoText}>{order.billingAddress.email}</p>
               )}
             </div>
+
+            {/* Point relais choisi */}
+            {order.pickupPoint && (
+              <div className={styles.infoCard}>
+                <h3 className={styles.cardTitle}>
+                  <MapPin size={18} />
+                  Point relais
+                </h3>
+                {order.pickupPoint.name && (
+                  <p className={styles.infoText}>
+                    <strong>{order.pickupPoint.name}</strong>
+                  </p>
+                )}
+                {order.pickupPoint.line1 && (
+                  <p className={styles.infoText}>{order.pickupPoint.line1}</p>
+                )}
+                <p className={styles.infoText}>
+                  {order.pickupPoint.postalCode} {order.pickupPoint.city}
+                </p>
+              </div>
+            )}
 
             {/* Adresse de livraison */}
             {order.shippingAddress && (

--- a/pokecard/src/OrderTrackingPage.tsx
+++ b/pokecard/src/OrderTrackingPage.tsx
@@ -5,6 +5,7 @@ import { API_BASE, getImageUrl } from './api';
 import styles from './OrderDetailPage.module.css';
 import {
   Package,
+  PackageOpen,
   Truck,
   CheckCircle,
   XCircle,
@@ -13,6 +14,7 @@ import {
   Calendar,
   Link as LinkIcon,
 } from 'lucide-react';
+import { getOrderDisplayStatus, ORDER_STATUS_TIMELINE } from './orderStatus';
 
 interface OrderItem {
   id: string;
@@ -39,6 +41,12 @@ interface Order {
   carrier?: string | null;
   trackingNumber?: string | null;
   trackingUrl?: string | null;
+  pickupPoint?: {
+    name?: string | null;
+    line1?: string | null;
+    postalCode?: string | null;
+    city?: string | null;
+  } | null;
   shippedAt?: string | null;
   deliveredAt?: string | null;
   totalCents: number;
@@ -84,6 +92,12 @@ const statusConfig = {
     color: '#3b82f6',
     bgColor: 'rgba(59, 130, 246, 0.1)',
   },
+  PREPARING: {
+    label: 'En préparation',
+    icon: PackageOpen,
+    color: '#f59e0b',
+    bgColor: 'rgba(245, 158, 11, 0.1)',
+  },
   SHIPPED: { label: 'Expédiée', icon: Truck, color: '#8b5cf6', bgColor: 'rgba(139, 92, 246, 0.1)' },
   DELIVERED: {
     label: 'Livrée',
@@ -105,7 +119,7 @@ const statusConfig = {
   },
 };
 
-const statusTimeline = ['PENDING', 'CONFIRMED', 'SHIPPED', 'DELIVERED'];
+const statusTimeline = ORDER_STATUS_TIMELINE;
 
 export function OrderTrackingPage() {
   const { orderId } = useParams<{ orderId: string }>();
@@ -168,7 +182,8 @@ export function OrderTrackingPage() {
       minute: '2-digit',
     });
 
-  const getStatusIndex = (status: string) => statusTimeline.indexOf(status);
+  const getStatusIndex = (status: (typeof statusTimeline)[number]) =>
+    statusTimeline.indexOf(status);
 
   if (loading) {
     return (
@@ -199,8 +214,9 @@ export function OrderTrackingPage() {
     );
   }
 
-  const StatusIcon = statusConfig[order.status].icon;
-  const currentStatusIndex = getStatusIndex(order.status);
+  const displayStatus = getOrderDisplayStatus(order.status, order.fulfillmentStatus);
+  const StatusIcon = statusConfig[displayStatus].icon;
+  const currentStatusIndex = getStatusIndex(displayStatus);
   const isCancelled = order.status === 'CANCELLED' || order.status === 'REFUNDED';
 
   return (
@@ -222,12 +238,12 @@ export function OrderTrackingPage() {
             <div
               className={styles.statusBadge}
               style={{
-                color: statusConfig[order.status].color,
-                backgroundColor: statusConfig[order.status].bgColor,
+                color: statusConfig[displayStatus].color,
+                backgroundColor: statusConfig[displayStatus].bgColor,
               }}
             >
               <StatusIcon size={18} />
-              {statusConfig[order.status].label}
+              {statusConfig[displayStatus].label}
             </div>
           </div>
         </div>
@@ -281,6 +297,14 @@ export function OrderTrackingPage() {
                 <span>Numéro de suivi</span>
                 <span>{order.trackingNumber || '—'}</span>
               </div>
+              {order.pickupPoint && (
+                <div className={styles.summaryLine}>
+                  <span>Point relais</span>
+                  <span>
+                    {[order.pickupPoint.name, order.pickupPoint.city].filter(Boolean).join(' — ')}
+                  </span>
+                </div>
+              )}
               {order.trackingUrl && (
                 <a
                   className={styles.trackingButton}

--- a/pokecard/src/OrdersPage.tsx
+++ b/pokecard/src/OrdersPage.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from './authContext';
 import { API_BASE, getImageUrl } from './api';
 import styles from './OrdersPage.module.css';
-import { Package, Truck, CheckCircle, XCircle, Clock, Eye } from 'lucide-react';
+import { Package, PackageOpen, Truck, CheckCircle, XCircle, Clock, Eye } from 'lucide-react';
+import { getOrderDisplayStatus } from './orderStatus';
 
 interface OrderItem {
   id: string;
@@ -19,6 +20,7 @@ interface Order {
   id: string;
   orderNumber: string;
   status: 'PENDING' | 'CONFIRMED' | 'SHIPPED' | 'DELIVERED' | 'CANCELLED' | 'REFUNDED';
+  fulfillmentStatus?: string;
   totalCents: number;
   currency: string;
   items: OrderItem[];
@@ -30,6 +32,7 @@ interface Order {
 const statusConfig = {
   PENDING: { label: 'En attente', icon: Clock, color: '#f59e0b' },
   CONFIRMED: { label: 'Confirmée', icon: CheckCircle, color: '#3b82f6' },
+  PREPARING: { label: 'En préparation', icon: PackageOpen, color: '#f59e0b' },
   SHIPPED: { label: 'Expédiée', icon: Truck, color: '#8b5cf6' },
   DELIVERED: { label: 'Livrée', icon: Package, color: '#10b981' },
   CANCELLED: { label: 'Annulée', icon: XCircle, color: '#ef4444' },
@@ -151,8 +154,9 @@ export function OrdersPage() {
         ) : (
           <div className={styles.ordersList}>
             {orders.map((order) => {
-              const StatusIcon = statusConfig[order.status].icon;
-              const statusColor = statusConfig[order.status].color;
+              const displayStatus = getOrderDisplayStatus(order.status, order.fulfillmentStatus);
+              const StatusIcon = statusConfig[displayStatus].icon;
+              const statusColor = statusConfig[displayStatus].color;
 
               return (
                 <div key={order.id} className={styles.orderCard}>
@@ -163,7 +167,7 @@ export function OrdersPage() {
                     </div>
                     <div className={styles.orderStatus} style={{ color: statusColor }}>
                       <StatusIcon className={styles.statusIcon} />
-                      <span>{statusConfig[order.status].label}</span>
+                      <span>{statusConfig[displayStatus].label}</span>
                     </div>
                   </div>
 

--- a/pokecard/src/api.ts
+++ b/pokecard/src/api.ts
@@ -106,13 +106,62 @@ export type ShippingInfo = {
   phone?: string;
 };
 
+// Point relais Boxtal retourné par GET /shipping/parcel-points
+export type ParcelPoint = {
+  code: string;
+  name: string;
+  networks?: string[];
+  address: {
+    number?: string;
+    street?: string;
+    postalCode?: string;
+    city?: string;
+    country?: string;
+  };
+  distanceMeters?: number;
+  latitude?: number;
+  longitude?: number;
+  openingDays?: Record<string, { open: string; close: string }[]>;
+};
+
+// Payload point relais envoyé au checkout
+export type PickupPointPayload = {
+  code: string;
+  name: string;
+  network?: string;
+  address: {
+    line1?: string;
+    postalCode?: string;
+    city?: string;
+    country?: string;
+  };
+};
+
+export async function searchParcelPoints(params: {
+  postalCode: string;
+  city?: string;
+  country?: string;
+  street?: string;
+}): Promise<ParcelPoint[]> {
+  const query = new URLSearchParams({ postalCode: params.postalCode });
+  if (params.city) query.set('city', params.city);
+  if (params.country) query.set('country', params.country);
+  if (params.street) query.set('street', params.street);
+
+  const res = await fetchJson<{ data: ParcelPoint[] }>(
+    `/shipping/parcel-points?${query.toString()}`
+  );
+  return res.data || [];
+}
+
 export async function createCheckoutSession(
   items: CheckoutItem[],
   email?: string,
   promoCode?: string,
   shipping?: ShippingInfo,
   shippingMethodCode?: string,
-  idempotencyKey?: string
+  idempotencyKey?: string,
+  pickupPoint?: PickupPointPayload
 ): Promise<{ url: string | null; sessionId?: string } | { url?: string; sessionId: string }> {
   // Construire les URLs de redirection basées sur l'origine actuelle
   const origin = window.location.origin;
@@ -147,6 +196,7 @@ export async function createCheckoutSession(
       cancelUrl,
       shipping,
       shippingMethodCode,
+      pickupPoint,
       gaClientId: readGaClientId(),
     };
 

--- a/pokecard/src/components/ParcelPointSelector.module.css
+++ b/pokecard/src/components/ParcelPointSelector.module.css
@@ -1,0 +1,178 @@
+.selector {
+  margin-top: 12px;
+  padding: 14px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 10px;
+  background: var(--color-bg-elevated);
+}
+
+.title {
+  margin: 0 0 10px;
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.searchRow {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.searchInput {
+  flex: 1 1 120px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--color-accent-primary);
+}
+
+.searchButton {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--color-accent-primary);
+  color: var(--color-text-inverse);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s var(--ease-out);
+}
+
+.searchButton:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.searchButton:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.error {
+  margin-top: 10px;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--color-error);
+}
+
+.hint {
+  margin: 10px 0 0;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.pointList {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.pointItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  background: var(--color-bg-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s var(--ease-out);
+}
+
+.pointItem:hover {
+  border-color: var(--color-accent-primary);
+}
+
+.pointHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.pointName {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.pointDistance {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.pointAddress {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.pointHours {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.selectedBox {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--color-success);
+  border-radius: 8px;
+  background: var(--color-bg-primary);
+}
+
+.selectedName {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.selectedAddress {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.changeButton {
+  padding: 8px 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.2s var(--ease-out);
+}
+
+.changeButton:hover {
+  border-color: var(--color-border-hover);
+}

--- a/pokecard/src/components/ParcelPointSelector.tsx
+++ b/pokecard/src/components/ParcelPointSelector.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { searchParcelPoints, type ParcelPoint } from '../api';
+import styles from './ParcelPointSelector.module.css';
+
+type ParcelPointSelectorProps = {
+  // Préremplissage depuis l'adresse de livraison saisie
+  defaultPostalCode?: string;
+  defaultCity?: string;
+  selected: ParcelPoint | null;
+  onSelect: (point: ParcelPoint | null) => void;
+};
+
+const DAY_LABELS: Record<string, string> = {
+  MONDAY: 'Lun',
+  TUESDAY: 'Mar',
+  WEDNESDAY: 'Mer',
+  THURSDAY: 'Jeu',
+  FRIDAY: 'Ven',
+  SATURDAY: 'Sam',
+  SUNDAY: 'Dim',
+};
+
+function formatDistance(meters?: number) {
+  if (typeof meters !== 'number') return null;
+  return meters >= 1000 ? `${(meters / 1000).toFixed(1)} km` : `${Math.round(meters)} m`;
+}
+
+function formatAddress(point: ParcelPoint) {
+  const line = [point.address.number, point.address.street].filter(Boolean).join(' ');
+  const cityLine = [point.address.postalCode, point.address.city].filter(Boolean).join(' ');
+  return [line, cityLine].filter(Boolean).join(', ');
+}
+
+export function ParcelPointSelector({
+  defaultPostalCode,
+  defaultCity,
+  selected,
+  onSelect,
+}: ParcelPointSelectorProps) {
+  const [postalCode, setPostalCode] = useState(defaultPostalCode || '');
+  const [city, setCity] = useState(defaultCity || '');
+  const [points, setPoints] = useState<ParcelPoint[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [searched, setSearched] = useState(false);
+  const autoSearchRanRef = useRef(false);
+
+  const runSearch = useCallback(async (searchPostalCode: string, searchCity: string) => {
+    const trimmedPostalCode = searchPostalCode.trim();
+    if (trimmedPostalCode.length < 2) {
+      setError('Veuillez renseigner un code postal.');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+    try {
+      const results = await searchParcelPoints({
+        postalCode: trimmedPostalCode,
+        city: searchCity.trim() || undefined,
+      });
+      setPoints(results);
+      setSearched(true);
+      if (results.length === 0) {
+        setError('Aucun point relais trouvé autour de cette adresse.');
+      }
+    } catch {
+      setError('La recherche de points relais a échoué. Veuillez réessayer.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Recherche automatique à l'affichage si le code postal est déjà connu
+  useEffect(() => {
+    if (autoSearchRanRef.current) return;
+    if (!defaultPostalCode || defaultPostalCode.trim().length < 4) return;
+    autoSearchRanRef.current = true;
+    runSearch(defaultPostalCode, defaultCity || '');
+  }, [defaultPostalCode, defaultCity, runSearch]);
+
+  return (
+    <div className={styles.selector}>
+      <p className={styles.title}>Choisissez votre point relais</p>
+
+      {selected && (
+        <div className={styles.selectedBox}>
+          <div>
+            <div className={styles.selectedName}>{selected.name}</div>
+            <div className={styles.selectedAddress}>{formatAddress(selected)}</div>
+          </div>
+          <button type="button" className={styles.changeButton} onClick={() => onSelect(null)}>
+            Changer
+          </button>
+        </div>
+      )}
+
+      {!selected && (
+        <>
+          <div className={styles.searchRow}>
+            <input
+              type="text"
+              inputMode="numeric"
+              placeholder="Code postal"
+              value={postalCode}
+              onChange={(e) => setPostalCode(e.target.value)}
+              className={styles.searchInput}
+              aria-label="Code postal du point relais"
+            />
+            <input
+              type="text"
+              placeholder="Ville (optionnel)"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              className={styles.searchInput}
+              aria-label="Ville du point relais"
+            />
+            <button
+              type="button"
+              className={styles.searchButton}
+              disabled={loading}
+              onClick={() => runSearch(postalCode, city)}
+            >
+              {loading ? 'Recherche…' : 'Rechercher'}
+            </button>
+          </div>
+
+          {error && <div className={styles.error}>{error}</div>}
+
+          {points.length > 0 && (
+            <ul className={styles.pointList}>
+              {points.map((point) => {
+                const distance = formatDistance(point.distanceMeters);
+                return (
+                  <li key={point.code}>
+                    <button
+                      type="button"
+                      className={styles.pointItem}
+                      onClick={() => onSelect(point)}
+                    >
+                      <span className={styles.pointHeader}>
+                        <span className={styles.pointName}>{point.name}</span>
+                        {distance && <span className={styles.pointDistance}>{distance}</span>}
+                      </span>
+                      <span className={styles.pointAddress}>{formatAddress(point)}</span>
+                      {point.openingDays && (
+                        <span className={styles.pointHours}>
+                          {Object.entries(point.openingDays)
+                            .filter(([, periods]) => periods.length > 0)
+                            .slice(0, 7)
+                            .map(
+                              ([day, periods]) =>
+                                `${DAY_LABELS[day] || day} ${periods
+                                  .map((p) => `${p.open}–${p.close}`)
+                                  .join(', ')}`
+                            )
+                            .join(' · ')}
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {!searched && !loading && !error && (
+            <p className={styles.hint}>
+              Renseignez votre code postal pour afficher les points relais proches de chez vous.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/pokecard/src/orderStatus.ts
+++ b/pokecard/src/orderStatus.ts
@@ -1,0 +1,30 @@
+// Statut d'affichage côté client : fusionne le statut commande (OrderStatus)
+// et le statut logistique (fulfillmentStatus) pour exposer l'étape
+// « En préparation » (étiquette créée, colis pas encore remis au transporteur).
+export type OrderDisplayStatus =
+  | 'PENDING'
+  | 'CONFIRMED'
+  | 'PREPARING'
+  | 'SHIPPED'
+  | 'DELIVERED'
+  | 'CANCELLED'
+  | 'REFUNDED';
+
+export function getOrderDisplayStatus(
+  status: string,
+  fulfillmentStatus?: string | null
+): OrderDisplayStatus {
+  if (fulfillmentStatus === 'PREPARING' && (status === 'CONFIRMED' || status === 'PENDING')) {
+    return 'PREPARING';
+  }
+  return status as OrderDisplayStatus;
+}
+
+// Étapes affichées dans les timelines de suivi (une commande visible est
+// toujours au moins confirmée : elle n'est créée qu'après paiement).
+export const ORDER_STATUS_TIMELINE: readonly OrderDisplayStatus[] = [
+  'CONFIRMED',
+  'PREPARING',
+  'SHIPPED',
+  'DELIVERED',
+];

--- a/pokecard/src/shippingMethods.ts
+++ b/pokecard/src/shippingMethods.ts
@@ -5,24 +5,28 @@ export type ShippingMethod = {
   carrier: string;
   enabled: boolean;
   description?: string;
+  // true si le client doit choisir un point relais au checkout (Boxtal)
+  requiresPickupPoint: boolean;
 };
 
 export const SHIPPING_METHODS: ShippingMethod[] = [
   {
     code: 'MONDIAL_RELAY',
-    label: 'Mondial Relay - Point relais',
+    label: 'Livraison en point relais',
     priceCents: 490,
     carrier: 'MONDIAL_RELAY',
     enabled: true,
     description: 'Livraison en point relais (3 à 5 jours)',
+    requiresPickupPoint: true,
   },
   {
     code: 'COLISSIMO_HOME',
-    label: 'Colissimo - Domicile',
+    label: 'Livraison à domicile',
     priceCents: 790,
     carrier: 'COLISSIMO',
     enabled: true,
     description: 'Livraison à domicile (3 à 5 jours ouvrés)',
+    requiresPickupPoint: false,
   },
 ];
 

--- a/server/env.example
+++ b/server/env.example
@@ -57,6 +57,42 @@ STRIPE_API_VERSION="2024-06-20"
 CHECKOUT_SUCCESS_URL="http://localhost:3000/checkout/success"
 CHECKOUT_CANCEL_URL="http://localhost:3000/panier"
 
+# ===== BOXTAL (expédition : points relais, étiquettes, suivi) =====
+# Clés API v3 (portail développeur Boxtal). Si vides, les fonctionnalités
+# Boxtal sont désactivées (recherche de relais, création d'étiquettes).
+BOXTAL_ACCESS_KEY=""
+BOXTAL_SECRET_KEY=""
+# Environnement API : test = https://api.boxtal.build, production = https://api.boxtal.com
+BOXTAL_API_BASE_URL="https://api.boxtal.build"
+# Codes des offres d'expédition (visibles dans votre espace Boxtal)
+# Ex relais : MONR-CpourToi (Mondial Relay), ex domicile : POFR-ColissimoAccess (Colissimo)
+BOXTAL_SHIPPING_OFFER_CODE_RELAY=""
+BOXTAL_SHIPPING_OFFER_CODE_HOME=""
+# Expéditeur (adresse de départ des colis, requis pour créer une étiquette)
+BOXTAL_SHIPPER_COMPANY="Boulevard TCG"
+BOXTAL_SHIPPER_FIRST_NAME=""
+BOXTAL_SHIPPER_LAST_NAME=""
+BOXTAL_SHIPPER_EMAIL="contact@boulevardtcg.com"
+BOXTAL_SHIPPER_PHONE=""
+BOXTAL_SHIPPER_ADDRESS=""
+# BOXTAL_SHIPPER_ADDRESS_2=""
+BOXTAL_SHIPPER_POSTAL_CODE=""
+BOXTAL_SHIPPER_CITY=""
+BOXTAL_SHIPPER_COUNTRY="FR"
+# Colis par défaut (poids estimé = base + poids par article)
+BOXTAL_PACKAGE_BASE_WEIGHT_GRAMS=150
+BOXTAL_PACKAGE_ITEM_WEIGHT_GRAMS=50
+BOXTAL_PACKAGE_LENGTH_CM=24
+BOXTAL_PACKAGE_WIDTH_CM=18
+BOXTAL_PACKAGE_HEIGHT_CM=8
+# Catégorie de contenu Boxtal (GET /content-category) et format d'étiquette
+# BOXTAL_CONTENT_CATEGORY_ID="content:v1:80100"
+# BOXTAL_CONTENT_DESCRIPTION="Cartes à collectionner et accessoires TCG"
+# BOXTAL_LABEL_TYPE="PDF_A4"
+# Clé de validation des webhooks Boxtal (fournie lors de la création des
+# souscriptions DOCUMENT_CREATED / TRACKING_CHANGED — endpoint : /api/shipping/boxtal/webhook)
+BOXTAL_WEBHOOK_SECRET=""
+
 # Google Analytics 4 — Measurement Protocol (event purchase serveur, optionnel)
 # Si vide, l'envoi est désactivé (no-op). API Secret : GA4 > Admin > Flux de données > Protocole de mesure.
 GA4_MEASUREMENT_ID="G-48XSD96XGF"

--- a/server/prisma/migrations/20260715120000_add_boxtal_shipping_fields/migration.sql
+++ b/server/prisma/migrations/20260715120000_add_boxtal_shipping_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: add Boxtal shipping fields (shipping order id, label, pickup point)
+ALTER TABLE "orders" ADD COLUMN "boxtalShippingOrderId" TEXT;
+ALTER TABLE "orders" ADD COLUMN "labelUrl" TEXT;
+ALTER TABLE "orders" ADD COLUMN "pickupPointCode" TEXT;
+ALTER TABLE "orders" ADD COLUMN "pickupPoint" JSONB;
+
+-- CreateIndex: unique constraint so one Boxtal shipping order maps to one order (webhook lookups)
+CREATE UNIQUE INDEX "orders_boxtalShippingOrderId_key" ON "orders"("boxtalShippingOrderId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -105,6 +105,11 @@ model Order {
   trackingUrl       String?
   shippedAt         DateTime?
   deliveredAt       DateTime?
+  // Boxtal (agrégateur d'expédition)
+  boxtalShippingOrderId String? @unique // Identifiant de la commande d'expédition Boxtal
+  labelUrl              String? // URL signée de l'étiquette PDF (expire côté Boxtal après 7 jours)
+  pickupPointCode       String? // Code du point relais choisi par le client
+  pickupPoint           Json? // Détails du point relais (nom, adresse, réseau)
   totalCents        Int
   currency          String            @default("EUR")
   paymentMethod     String?

--- a/server/scripts/boxtal-smoke.mts
+++ b/server/scripts/boxtal-smoke.mts
@@ -1,0 +1,94 @@
+/**
+ * Smoke test Boxtal : valide la configuration .env contre l'API en exerçant
+ * le vrai code du service (recherche de relais → création d'expédition →
+ * suivi + étiquette → annulation).
+ *
+ * Usage : npx tsx scripts/boxtal-smoke.mts
+ * Refuse de tourner contre la production (créerait une étiquette facturée),
+ * sauf avec --allow-prod.
+ */
+import 'dotenv/config';
+import { getBoxtalConfig } from '../src/config/boxtal.js';
+import {
+  searchParcelPoints,
+  createShippingOrder,
+  getShippingOrderTracking,
+  getShippingLabelUrl,
+  cancelShippingOrder,
+} from '../src/services/boxtal.js';
+
+const config = getBoxtalConfig();
+if (!config) {
+  console.error('❌ BOXTAL_ACCESS_KEY / BOXTAL_SECRET_KEY manquants dans .env');
+  process.exit(1);
+}
+
+const isTestEnv = config.baseUrl.includes('boxtal.build');
+if (!isTestEnv && !process.argv.includes('--allow-prod')) {
+  console.error(
+    `❌ ${config.baseUrl} est l'environnement de PRODUCTION : une expédition y serait facturée.\n` +
+      '   Relancez avec --allow-prod si c’est volontaire.'
+  );
+  process.exit(1);
+}
+
+console.log(`Environnement : ${config.baseUrl} ${isTestEnv ? '(test, non facturé)' : '(PRODUCTION)'}`);
+
+// 1. Recherche de points relais
+console.log('\n1/4 Recherche de points relais autour de 75002 Paris…');
+const points = await searchParcelPoints({ postalCode: '75002', city: 'Paris' });
+if (points.length === 0) {
+  console.error('❌ Aucun point relais retourné — vérifier BOXTAL_SHIPPING_OFFER_CODE_RELAY');
+  process.exit(1);
+}
+console.log(`✅ ${points.length} points trouvés. Premier : ${points[0].name} (${points[0].code})`);
+
+// 2. Création d'une expédition relais
+console.log('\n2/4 Création d’une expédition relais de test…');
+const shipment = await createShippingOrder({
+  externalId: `smoke-${Date.now()}`,
+  offerType: 'RELAY',
+  pickupPointCode: points[0].code,
+  recipient: {
+    name: 'Client Test',
+    email: 'client.test@example.com',
+    phone: '0611223344',
+    line1: '1 rue de Rivoli',
+    postalCode: '75001',
+    city: 'Paris',
+    country: 'FR',
+  },
+  itemsCount: 2,
+  valueCents: 2500,
+});
+console.log(`✅ Expédition créée : ${shipment.boxtalShippingOrderId} (statut ${shipment.status})`);
+
+// 3. Suivi + étiquette (peuvent être différés côté Boxtal)
+console.log('\n3/4 Récupération suivi + étiquette…');
+const [tracking, labelUrl] = await Promise.all([
+  getShippingOrderTracking(shipment.boxtalShippingOrderId),
+  getShippingLabelUrl(shipment.boxtalShippingOrderId),
+]);
+console.log(
+  tracking
+    ? `✅ Suivi : ${tracking.status ?? '—'} ${tracking.trackingNumber ?? '(numéro pas encore attribué)'}`
+    : 'ℹ️ Suivi pas encore disponible (normal juste après création — le webhook le complètera)'
+);
+console.log(
+  labelUrl
+    ? `✅ Étiquette : ${labelUrl.slice(0, 80)}…`
+    : 'ℹ️ Étiquette pas encore générée (normal juste après création — le webhook la complètera)'
+);
+
+// 4. Annulation pour laisser l'environnement propre
+console.log('\n4/4 Annulation de l’expédition de test…');
+try {
+  await cancelShippingOrder(shipment.boxtalShippingOrderId);
+  console.log('✅ Expédition annulée');
+} catch (err) {
+  console.log(
+    `ℹ️ Annulation impossible (${(err as Error).message}) — sans conséquence en environnement de test`
+  );
+}
+
+console.log('\n🎉 Configuration Boxtal opérationnelle.');

--- a/server/src/__tests__/boxtal.test.ts
+++ b/server/src/__tests__/boxtal.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Carrier, FulfillmentStatus } from '@prisma/client';
+import {
+  searchParcelPoints,
+  createShippingOrder,
+  getShippingOrderTracking,
+  getShippingLabelUrl,
+  carrierFromOfferCode,
+  fulfillmentStatusFromTracking,
+  normalizePhone,
+  normalizeCountryIso2,
+  BoxtalApiError,
+} from '../services/boxtal.js';
+import { getBoxtalConfig, splitStreetLine } from '../config/boxtal.js';
+import { verifyBoxtalSignature } from '../routes/shipping.js';
+import crypto from 'crypto';
+
+const BOXTAL_ENV_KEYS = [
+  'BOXTAL_ACCESS_KEY',
+  'BOXTAL_SECRET_KEY',
+  'BOXTAL_API_BASE_URL',
+  'BOXTAL_SHIPPING_OFFER_CODE_RELAY',
+  'BOXTAL_SHIPPING_OFFER_CODE_HOME',
+  'BOXTAL_SHIPPER_COMPANY',
+  'BOXTAL_SHIPPER_FIRST_NAME',
+  'BOXTAL_SHIPPER_LAST_NAME',
+  'BOXTAL_SHIPPER_EMAIL',
+  'BOXTAL_SHIPPER_PHONE',
+  'BOXTAL_SHIPPER_ADDRESS',
+  'BOXTAL_SHIPPER_POSTAL_CODE',
+  'BOXTAL_SHIPPER_CITY',
+  'BOXTAL_WEBHOOK_SECRET',
+];
+
+function setBoxtalEnv() {
+  process.env.BOXTAL_ACCESS_KEY = 'test-access-key';
+  process.env.BOXTAL_SECRET_KEY = 'test-secret-key';
+  process.env.BOXTAL_API_BASE_URL = 'https://api.boxtal.test';
+  process.env.BOXTAL_SHIPPING_OFFER_CODE_RELAY = 'MONR-CpourToi';
+  process.env.BOXTAL_SHIPPING_OFFER_CODE_HOME = 'POFR-ColissimoAccess';
+  process.env.BOXTAL_SHIPPER_COMPANY = 'BoulevardTCG';
+  process.env.BOXTAL_SHIPPER_FIRST_NAME = 'Vincent';
+  process.env.BOXTAL_SHIPPER_LAST_NAME = 'Morais';
+  process.env.BOXTAL_SHIPPER_EMAIL = 'contact@boulevardtcg.com';
+  process.env.BOXTAL_SHIPPER_PHONE = '0612345678';
+  process.env.BOXTAL_SHIPPER_ADDRESS = '10 rue des Cartes';
+  process.env.BOXTAL_SHIPPER_POSTAL_CODE = '75001';
+  process.env.BOXTAL_SHIPPER_CITY = 'Paris';
+}
+
+function clearBoxtalEnv() {
+  for (const key of BOXTAL_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function mockFetchOnce(status: number, payload: unknown) {
+  const fn = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+    Promise.resolve(
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+  );
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+describe('Boxtal config', () => {
+  beforeEach(() => clearBoxtalEnv());
+  afterEach(() => {
+    clearBoxtalEnv();
+    vi.unstubAllGlobals();
+  });
+
+  it('retourne null sans clés API', () => {
+    expect(getBoxtalConfig()).toBeNull();
+  });
+
+  it('retourne la config avec les clés définies', () => {
+    setBoxtalEnv();
+    const config = getBoxtalConfig();
+    expect(config).not.toBeNull();
+    expect(config!.baseUrl).toBe('https://api.boxtal.test');
+    expect(config!.offerCodes.RELAY).toBe('MONR-CpourToi');
+    expect(config!.shipper?.company).toBe('BoulevardTCG');
+    expect(config!.shipper?.street).toBe('rue des Cartes');
+    expect(config!.shipper?.number).toBe('10');
+  });
+
+  it('splitStreetLine sépare le numéro de voie', () => {
+    expect(splitStreetLine('12 bis rue de la Paix')).toEqual({
+      number: '12',
+      street: 'bis rue de la Paix',
+    });
+    expect(splitStreetLine('Chemin des Vignes')).toEqual({ street: 'Chemin des Vignes' });
+  });
+});
+
+describe('searchParcelPoints', () => {
+  beforeEach(() => {
+    clearBoxtalEnv();
+    setBoxtalEnv();
+  });
+  afterEach(() => {
+    clearBoxtalEnv();
+    vi.unstubAllGlobals();
+  });
+
+  it('normalise la réponse Boxtal (clé parcelPoint, constatée sur l’API de test)', async () => {
+    const fetchMock = mockFetchOnce(200, {
+      content: [
+        {
+          parcelPoint: {
+            code: '12345',
+            name: 'Tabac de la Gare',
+            location: {
+              street: 'rue de la Gare',
+              number: '3',
+              city: 'Paris',
+              postalCode: '75001',
+              countryIsoCode: 'FR',
+              position: { latitude: '48.8592', longitude: '2.3467' },
+            },
+            openingDays: {
+              MONDAY: [{ openingTime: '09:00', closingTime: '19:00' }],
+            },
+            compatibleNetworks: ['MONR_NETWORK'],
+          },
+          distanceFromSearchLocation: 250,
+        },
+      ],
+    });
+
+    const points = await searchParcelPoints({ postalCode: '75001', city: 'Paris' });
+
+    expect(points).toHaveLength(1);
+    expect(points[0]).toMatchObject({
+      code: '12345',
+      name: 'Tabac de la Gare',
+      networks: ['MONR_NETWORK'],
+      distanceMeters: 250,
+      latitude: 48.8592,
+      longitude: 2.3467,
+    });
+    expect(points[0].address).toMatchObject({
+      street: 'rue de la Gare',
+      number: '3',
+      postalCode: '75001',
+      city: 'Paris',
+      country: 'FR',
+    });
+    expect(points[0].openingDays?.MONDAY).toEqual([{ open: '09:00', close: '19:00' }]);
+
+    const calledUrl = String(fetchMock.mock.calls[0][0]);
+    expect(calledUrl).toContain('/shipping/v3.2/parcel-point-by-shipping-offer');
+    expect(calledUrl).toContain('shippingOfferCode=MONR-CpourToi');
+    expect(calledUrl).toContain('operationType=ARRIVAL');
+  });
+
+  it("échoue si l'offre relais n'est pas configurée", async () => {
+    delete process.env.BOXTAL_SHIPPING_OFFER_CODE_RELAY;
+    await expect(searchParcelPoints({ postalCode: '75001' })).rejects.toMatchObject({
+      code: 'BOXTAL_NOT_CONFIGURED',
+    });
+  });
+
+  it('propage les erreurs API Boxtal', async () => {
+    mockFetchOnce(401, { messages: [{ text: 'Unauthorized', severity: 'ERROR' }] });
+    await expect(searchParcelPoints({ postalCode: '75001' })).rejects.toBeInstanceOf(
+      BoxtalApiError
+    );
+  });
+});
+
+describe('createShippingOrder', () => {
+  beforeEach(() => {
+    clearBoxtalEnv();
+    setBoxtalEnv();
+  });
+  afterEach(() => {
+    clearBoxtalEnv();
+    vi.unstubAllGlobals();
+  });
+
+  const recipient = {
+    name: 'Jean Dupont',
+    email: 'jean@example.com',
+    phone: '0699887766',
+    line1: '5 avenue des Champs',
+    postalCode: '75008',
+    city: 'Paris',
+    country: 'FR',
+  };
+
+  it("crée l'expédition et retourne l'identifiant Boxtal", async () => {
+    const fetchMock = mockFetchOnce(200, {
+      content: { id: '2440000000MONR4IA8FR', status: 'PENDING' },
+    });
+
+    const result = await createShippingOrder({
+      externalId: 'order-1',
+      offerType: 'RELAY',
+      pickupPointCode: '99439',
+      recipient,
+      itemsCount: 3,
+      valueCents: 4500,
+    });
+
+    expect(result.boxtalShippingOrderId).toBe('2440000000MONR4IA8FR');
+    expect(result.offerCode).toBe('MONR-CpourToi');
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init!.body as string);
+    expect(body.shippingOfferCode).toBe('MONR-CpourToi');
+    expect(body.shipment.pickupPointCode).toBe('99439');
+    expect(body.shipment.externalId).toBe('order-1');
+    expect(body.shipment.toAddress.contact.phone).toBe('+33699887766');
+    expect(body.shipment.toAddress.location).toMatchObject({
+      street: 'avenue des Champs',
+      number: '5',
+      postalCode: '75008',
+      city: 'Paris',
+      countryIsoCode: 'FR',
+    });
+    // Valeur du colis en euros et poids estimé (base 150g + 3 × 50g)
+    expect(body.shipment.packages[0].value.value).toBe(45);
+    expect(body.shipment.packages[0].weight).toBe(0.3);
+  });
+
+  it('utilise le code HOME pour une livraison à domicile', async () => {
+    const fetchMock = mockFetchOnce(200, { content: { id: 'ID-HOME', status: 'PENDING' } });
+
+    const result = await createShippingOrder({
+      externalId: 'order-2',
+      offerType: 'HOME',
+      recipient,
+      itemsCount: 1,
+      valueCents: 1000,
+    });
+
+    expect(result.offerCode).toBe('POFR-ColissimoAccess');
+    const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+    expect(body.shipment.pickupPointCode).toBeUndefined();
+  });
+
+  it('refuse une expédition relais sans point relais', async () => {
+    await expect(
+      createShippingOrder({
+        externalId: 'order-3',
+        offerType: 'RELAY',
+        recipient,
+        itemsCount: 1,
+        valueCents: 1000,
+      })
+    ).rejects.toMatchObject({ code: 'PICKUP_POINT_REQUIRED' });
+  });
+
+  it("échoue si l'expéditeur n'est pas configuré", async () => {
+    delete process.env.BOXTAL_SHIPPER_EMAIL;
+    await expect(
+      createShippingOrder({
+        externalId: 'order-4',
+        offerType: 'HOME',
+        recipient,
+        itemsCount: 1,
+        valueCents: 1000,
+      })
+    ).rejects.toMatchObject({ code: 'BOXTAL_NOT_CONFIGURED' });
+  });
+});
+
+describe('tracking et documents', () => {
+  beforeEach(() => {
+    clearBoxtalEnv();
+    setBoxtalEnv();
+  });
+  afterEach(() => {
+    clearBoxtalEnv();
+    vi.unstubAllGlobals();
+  });
+
+  it('récupère le suivi', async () => {
+    mockFetchOnce(200, {
+      content: [
+        {
+          status: 'IN_TRANSIT',
+          trackingNumber: 'TN123',
+          packageTrackingUrl: 'https://tracking.example/TN123',
+        },
+      ],
+    });
+
+    const tracking = await getShippingOrderTracking('BOXTAL-1');
+    expect(tracking).toEqual({
+      status: 'IN_TRANSIT',
+      trackingNumber: 'TN123',
+      trackingUrl: 'https://tracking.example/TN123',
+    });
+  });
+
+  it('retourne null quand le suivi est indisponible (422)', async () => {
+    mockFetchOnce(422, { messages: [{ text: 'NoPackageTrackingFoundException' }] });
+    expect(await getShippingOrderTracking('BOXTAL-1')).toBeNull();
+  });
+
+  it("récupère l'URL de l'étiquette LABEL", async () => {
+    mockFetchOnce(200, {
+      content: [
+        { url: 'https://document.boxtal.test/proforma.pdf', type: 'PROFORMA', format: 'PDF_A4' },
+        { url: 'https://document.boxtal.test/label.pdf', type: 'LABEL', format: 'PDF_A4' },
+      ],
+    });
+    expect(await getShippingLabelUrl('BOXTAL-1')).toBe('https://document.boxtal.test/label.pdf');
+  });
+
+  it("retourne null quand l'étiquette n'est pas générée (422)", async () => {
+    mockFetchOnce(422, { messages: [{ text: 'NoShippingDocumentException' }] });
+    expect(await getShippingLabelUrl('BOXTAL-1')).toBeNull();
+  });
+});
+
+describe('mappings Boxtal', () => {
+  it('carrierFromOfferCode mappe les préfixes opérateur', () => {
+    expect(carrierFromOfferCode('MONR-CpourToi')).toBe(Carrier.MONDIAL_RELAY);
+    expect(carrierFromOfferCode('POFR-ColissimoAccess')).toBe(Carrier.COLISSIMO);
+    expect(carrierFromOfferCode('CHRP-Chrono13')).toBe(Carrier.CHRONOPOST);
+    expect(carrierFromOfferCode('UPSE-Standard')).toBe(Carrier.UPS);
+    expect(carrierFromOfferCode('XXXX-Inconnu')).toBe(Carrier.OTHER);
+    expect(carrierFromOfferCode(null)).toBe(Carrier.OTHER);
+  });
+
+  it('fulfillmentStatusFromTracking mappe les statuts de suivi', () => {
+    expect(fulfillmentStatusFromTracking('SHIPPED')).toBe(FulfillmentStatus.SHIPPED);
+    expect(fulfillmentStatusFromTracking('IN_TRANSIT')).toBe(FulfillmentStatus.SHIPPED);
+    expect(fulfillmentStatusFromTracking('REACHED_DELIVERY_PICKUP_POINT')).toBe(
+      FulfillmentStatus.SHIPPED
+    );
+    expect(fulfillmentStatusFromTracking('DELIVERED')).toBe(FulfillmentStatus.DELIVERED);
+    expect(fulfillmentStatusFromTracking('ANNOUNCED')).toBeNull();
+    expect(fulfillmentStatusFromTracking(undefined)).toBeNull();
+  });
+
+  it('normalizePhone convertit au format international', () => {
+    expect(normalizePhone('0612345678')).toBe('+33612345678');
+    expect(normalizePhone('+33 6 12 34 56 78')).toBe('+33612345678');
+    expect(normalizePhone('33612345678')).toBe('+33612345678');
+  });
+
+  it('normalizeCountryIso2 gère les noms de pays français', () => {
+    expect(normalizeCountryIso2('France')).toBe('FR');
+    expect(normalizeCountryIso2('BELGIQUE')).toBe('BE');
+    expect(normalizeCountryIso2('fr')).toBe('FR');
+    expect(normalizeCountryIso2(undefined)).toBe('FR');
+  });
+});
+
+describe('verifyBoxtalSignature', () => {
+  const secret = 'webhook-secret';
+  const body = JSON.stringify({ type: 'TRACKING_CHANGED' });
+
+  it('accepte une signature hex valide', () => {
+    const signature = crypto.createHmac('sha256', secret).update(body).digest('hex');
+    expect(verifyBoxtalSignature(Buffer.from(body), signature, secret)).toBe(true);
+  });
+
+  it('accepte une signature base64 valide', () => {
+    const signature = crypto.createHmac('sha256', secret).update(body).digest('base64');
+    expect(verifyBoxtalSignature(Buffer.from(body), signature, secret)).toBe(true);
+  });
+
+  it('rejette une signature invalide', () => {
+    expect(verifyBoxtalSignature(Buffer.from(body), 'forged', secret)).toBe(false);
+    expect(verifyBoxtalSignature(Buffer.from(body), undefined, secret)).toBe(false);
+  });
+
+  it('rejette un corps non brut (objet déjà parsé)', () => {
+    const signature = crypto.createHmac('sha256', secret).update(body).digest('hex');
+    expect(verifyBoxtalSignature({} as unknown as Buffer, signature, secret)).toBe(false);
+  });
+});

--- a/server/src/__tests__/checkout.test.ts
+++ b/server/src/__tests__/checkout.test.ts
@@ -30,6 +30,19 @@ vi.mock('../config/stripe.js', () => ({
   },
 }));
 
+// Point relais valide pour les modes de livraison en relais (Boxtal)
+const testPickupPoint = {
+  code: 'MONR-12345',
+  name: 'Tabac de la Gare',
+  network: 'MONR_NETWORK',
+  address: {
+    line1: '12 rue de la Gare',
+    postalCode: '75001',
+    city: 'Paris',
+    country: 'FR',
+  },
+};
+
 describe('Checkout Routes', () => {
   let testUser: any;
   let testUserToken: string;
@@ -82,6 +95,7 @@ describe('Checkout Routes', () => {
           successUrl: 'http://localhost:3000/checkout/success',
           cancelUrl: 'http://localhost:3000/panier',
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',
@@ -110,6 +124,7 @@ describe('Checkout Routes', () => {
           successUrl: 'http://localhost:3000/checkout/success',
           cancelUrl: 'http://localhost:3000/panier',
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',
@@ -146,6 +161,7 @@ describe('Checkout Routes', () => {
             },
           ],
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',
@@ -171,6 +187,7 @@ describe('Checkout Routes', () => {
             },
           ],
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',
@@ -198,6 +215,7 @@ describe('Checkout Routes', () => {
             },
           ],
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',
@@ -247,6 +265,7 @@ describe('Checkout Routes', () => {
             },
           ],
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',
@@ -258,6 +277,67 @@ describe('Checkout Routes', () => {
 
       expect(response.status).toBe(201);
       expect(response.body).toHaveProperty('sessionId');
+    });
+
+    it('devrait rejeter une livraison en relais sans point relais', async () => {
+      const response = await request(app)
+        .post('/api/checkout/create-session')
+        .set('Authorization', `Bearer ${testUserToken}`)
+        .send({
+          items: [{ variantId: testVariant.id, quantity: 1 }],
+          shippingMethodCode: 'MONDIAL_RELAY',
+          shipping: {
+            fullName: 'Test User',
+            addressLine1: '123 Test St',
+            postalCode: '75001',
+            city: 'Paris',
+            country: 'France',
+          },
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('INVALID_PICKUP_POINT');
+    });
+
+    it('devrait accepter une livraison à domicile sans point relais', async () => {
+      const response = await request(app)
+        .post('/api/checkout/create-session')
+        .set('Authorization', `Bearer ${testUserToken}`)
+        .send({
+          items: [{ variantId: testVariant.id, quantity: 1 }],
+          shippingMethodCode: 'COLISSIMO_HOME',
+          shipping: {
+            fullName: 'Test User',
+            addressLine1: '123 Test St',
+            postalCode: '75001',
+            city: 'Paris',
+            country: 'France',
+          },
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('sessionId');
+    });
+
+    it('devrait rejeter un point relais au format invalide', async () => {
+      const response = await request(app)
+        .post('/api/checkout/create-session')
+        .set('Authorization', `Bearer ${testUserToken}`)
+        .send({
+          items: [{ variantId: testVariant.id, quantity: 1 }],
+          shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: { code: '<script>', name: 'X' },
+          shipping: {
+            fullName: 'Test User',
+            addressLine1: '123 Test St',
+            postalCode: '75001',
+            city: 'Paris',
+            country: 'France',
+          },
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('INVALID_PICKUP_POINT');
     });
 
     it('devrait exiger un mode de livraison', async () => {
@@ -326,6 +406,7 @@ describe('Checkout Routes', () => {
           successUrl: 'http://localhost:3000/checkout/success',
           cancelUrl: 'http://localhost:3000/panier',
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',
@@ -364,6 +445,7 @@ describe('Checkout Routes', () => {
           successUrl: 'http://localhost:3000/checkout/success',
           cancelUrl: 'http://localhost:3000/panier',
           shippingMethodCode: 'MONDIAL_RELAY',
+          pickupPoint: testPickupPoint,
           shipping: {
             fullName: 'Test User',
             addressLine1: '123 Test St',

--- a/server/src/__tests__/shipping-routes.test.ts
+++ b/server/src/__tests__/shipping-routes.test.ts
@@ -1,0 +1,443 @@
+import request from 'supertest';
+import crypto from 'crypto';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { createApp } from '../app.js';
+import { cleanupDatabase, createTestUser, prisma } from './setup.js';
+import { generateAccessToken } from '../utils/auth.js';
+
+const app = createApp();
+
+// Mock email service pour éviter d'envoyer de vrais emails
+vi.mock('../services/email.js', () => ({
+  sendShippingNotificationEmail: vi.fn(() => Promise.resolve(true)),
+  sendDeliveryConfirmationEmail: vi.fn(() => Promise.resolve(true)),
+  sendOrderConfirmationEmail: vi.fn(() => Promise.resolve(true)),
+}));
+
+const WEBHOOK_SECRET = 'test-boxtal-webhook-secret';
+
+const BOXTAL_TEST_ENV: Record<string, string> = {
+  BOXTAL_ACCESS_KEY: 'test-access-key',
+  BOXTAL_SECRET_KEY: 'test-secret-key',
+  BOXTAL_API_BASE_URL: 'https://api.boxtal.test',
+  BOXTAL_SHIPPING_OFFER_CODE_RELAY: 'MONR-CpourToi',
+  BOXTAL_SHIPPING_OFFER_CODE_HOME: 'POFR-ColissimoAccess',
+  BOXTAL_SHIPPER_COMPANY: 'BoulevardTCG',
+  BOXTAL_SHIPPER_FIRST_NAME: 'Vincent',
+  BOXTAL_SHIPPER_LAST_NAME: 'Morais',
+  BOXTAL_SHIPPER_EMAIL: 'contact@boulevardtcg.com',
+  BOXTAL_SHIPPER_PHONE: '0612345678',
+  BOXTAL_SHIPPER_ADDRESS: '10 rue des Cartes',
+  BOXTAL_SHIPPER_POSTAL_CODE: '75001',
+  BOXTAL_SHIPPER_CITY: 'Paris',
+  BOXTAL_WEBHOOK_SECRET: WEBHOOK_SECRET,
+};
+
+function setBoxtalEnv() {
+  Object.assign(process.env, BOXTAL_TEST_ENV);
+}
+
+function clearBoxtalEnv() {
+  for (const key of Object.keys(BOXTAL_TEST_ENV)) {
+    delete process.env[key];
+  }
+}
+
+const boxtalResponse = (status: number, payload: unknown) =>
+  Promise.resolve(
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+
+/**
+ * Stub de l'API Boxtal pour l'endpoint admin : création d'expédition OK,
+ * suivi paramétrable (null = pas encore disponible), étiquette disponible.
+ */
+function stubBoxtalApi(options: { trackingStatus?: string | null } = {}) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/tracking')) {
+        return options.trackingStatus
+          ? boxtalResponse(200, {
+              content: [
+                {
+                  status: options.trackingStatus,
+                  trackingNumber: 'TN-99',
+                  packageTrackingUrl: 'https://tracking.example/TN-99',
+                },
+              ],
+            })
+          : boxtalResponse(422, {});
+      }
+      if (url.includes('/shipping-document')) {
+        return boxtalResponse(200, {
+          content: [{ url: 'https://document.boxtal.test/admin-label.pdf', type: 'LABEL' }],
+        });
+      }
+      if (url.includes('/shipping-order')) {
+        return boxtalResponse(200, { content: { id: 'BOXTAL-ADMIN-1', status: 'PENDING' } });
+      }
+      return boxtalResponse(404, {});
+    })
+  );
+}
+
+function signBody(body: string) {
+  return crypto.createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex');
+}
+
+async function createTestOrder(overrides: Record<string, unknown> = {}) {
+  return prisma.order.create({
+    data: {
+      orderNumber: `BLVD-TEST-${Math.floor(Math.random() * 1_000_000)}`,
+      totalCents: 5000,
+      currency: 'EUR',
+      status: 'CONFIRMED',
+      fulfillmentStatus: 'PAID',
+      ...overrides,
+    },
+  });
+}
+
+describe('Shipping routes', () => {
+  beforeEach(() => {
+    clearBoxtalEnv();
+  });
+  afterEach(() => {
+    clearBoxtalEnv();
+    vi.unstubAllGlobals();
+  });
+
+  describe('GET /api/shipping/methods', () => {
+    it('retourne les modes de livraison actifs', async () => {
+      const response = await request(app).get('/api/shipping/methods');
+      expect(response.status).toBe(200);
+      const codes = response.body.data.map((m: { code: string }) => m.code);
+      expect(codes).toContain('MONDIAL_RELAY');
+      expect(codes).toContain('COLISSIMO_HOME');
+      const relay = response.body.data.find((m: { code: string }) => m.code === 'MONDIAL_RELAY');
+      expect(relay.requiresPickupPoint).toBe(true);
+    });
+  });
+
+  describe('GET /api/shipping/parcel-points', () => {
+    it('rejette une requête sans code postal', async () => {
+      const response = await request(app).get('/api/shipping/parcel-points');
+      expect(response.status).toBe(400);
+    });
+
+    it("retourne 503 quand Boxtal n'est pas configuré", async () => {
+      const response = await request(app).get('/api/shipping/parcel-points?postalCode=75001');
+      expect(response.status).toBe(503);
+      expect(response.body.error.code).toBe('BOXTAL_NOT_CONFIGURED');
+    });
+
+    it('retourne les points relais normalisés', async () => {
+      setBoxtalEnv();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [
+                  {
+                    parcelpoint: {
+                      code: '99439',
+                      name: 'Relais des Lilas',
+                      location: {
+                        street: 'rue des Lilas',
+                        number: '8',
+                        city: 'Paris',
+                        postalCode: '75019',
+                        countryIsoCode: 'FR',
+                      },
+                    },
+                    distanceFromSearchLocation: 120,
+                  },
+                ],
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } }
+            )
+          )
+        )
+      );
+
+      const response = await request(app).get(
+        '/api/shipping/parcel-points?postalCode=75019&city=Paris'
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0]).toMatchObject({
+        code: '99439',
+        name: 'Relais des Lilas',
+        distanceMeters: 120,
+      });
+    });
+  });
+
+  describe('POST /api/shipping/boxtal/webhook', () => {
+    beforeAll(async () => {
+      await cleanupDatabase();
+    });
+
+    afterAll(async () => {
+      await cleanupDatabase();
+      await prisma.$disconnect();
+    });
+
+    beforeEach(async () => {
+      await cleanupDatabase();
+      setBoxtalEnv();
+    });
+
+    it("retourne 503 quand le secret webhook n'est pas configuré", async () => {
+      delete process.env.BOXTAL_WEBHOOK_SECRET;
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .send('{}');
+      expect(response.status).toBe(503);
+    });
+
+    it('rejette une signature invalide', async () => {
+      const body = JSON.stringify({ type: 'TRACKING_CHANGED' });
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .set('x-bxt-signature', 'forged-signature')
+        .send(body);
+      expect(response.status).toBe(401);
+    });
+
+    it('rejette une requête sans signature', async () => {
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .send('{}');
+      expect(response.status).toBe(401);
+    });
+
+    it('met à jour le suivi et passe la commande en SHIPPED (TRACKING_CHANGED)', async () => {
+      const order = await createTestOrder({ boxtalShippingOrderId: 'BOXTAL-TRACK-1' });
+
+      const body = JSON.stringify({
+        id: 'evt-1',
+        type: 'TRACKING_CHANGED',
+        shippingOrderId: 'BOXTAL-TRACK-1',
+        payload: {
+          trackings: [
+            {
+              status: 'SHIPPED',
+              trackingNumber: 'TN-42',
+              packageTrackingUrl: 'https://tracking.example/TN-42',
+            },
+          ],
+        },
+      });
+
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .set('x-bxt-signature', signBody(body))
+        .send(body);
+
+      expect(response.status).toBe(200);
+
+      const updated = await prisma.order.findUnique({ where: { id: order.id } });
+      expect(updated?.trackingNumber).toBe('TN-42');
+      expect(updated?.trackingUrl).toBe('https://tracking.example/TN-42');
+      expect(updated?.fulfillmentStatus).toBe('SHIPPED');
+      expect(updated?.shippedAt).not.toBeNull();
+    });
+
+    it('passe la commande en DELIVERED avec deliveredAt', async () => {
+      const order = await createTestOrder({
+        boxtalShippingOrderId: 'BOXTAL-TRACK-2',
+        fulfillmentStatus: 'SHIPPED',
+        status: 'SHIPPED',
+        shippedAt: new Date(),
+      });
+
+      const body = JSON.stringify({
+        type: 'TRACKING_CHANGED',
+        shippingOrderId: 'BOXTAL-TRACK-2',
+        payload: { trackings: [{ status: 'DELIVERED', trackingNumber: 'TN-43' }] },
+      });
+
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .set('x-bxt-signature', signBody(body))
+        .send(body);
+
+      expect(response.status).toBe(200);
+
+      const updated = await prisma.order.findUnique({ where: { id: order.id } });
+      expect(updated?.fulfillmentStatus).toBe('DELIVERED');
+      expect(updated?.deliveredAt).not.toBeNull();
+    });
+
+    it("enregistre l'étiquette (DOCUMENT_CREATED) via l'externalId", async () => {
+      const order = await createTestOrder();
+
+      const body = JSON.stringify({
+        type: 'DOCUMENT_CREATED',
+        shipmentExternalId: order.id,
+        payload: {
+          documents: [
+            { url: 'https://document.boxtal.test/label.pdf', type: 'LABEL', format: 'PDF_A4' },
+          ],
+        },
+      });
+
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .set('x-bxt-signature', signBody(body))
+        .send(body);
+
+      expect(response.status).toBe(200);
+
+      const updated = await prisma.order.findUnique({ where: { id: order.id } });
+      expect(updated?.labelUrl).toBe('https://document.boxtal.test/label.pdf');
+    });
+
+    it('répond 200 pour une commande inconnue (pas de rejeu Boxtal)', async () => {
+      const body = JSON.stringify({
+        type: 'TRACKING_CHANGED',
+        shippingOrderId: 'BOXTAL-INCONNU',
+        payload: { trackings: [{ status: 'SHIPPED', trackingNumber: 'TN-44' }] },
+      });
+
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .set('x-bxt-signature', signBody(body))
+        .send(body);
+
+      expect(response.status).toBe(200);
+    });
+
+    it('fait passer une commande PREPARING en SHIPPED au premier scan transporteur', async () => {
+      const order = await createTestOrder({
+        boxtalShippingOrderId: 'BOXTAL-TRACK-3',
+        fulfillmentStatus: 'PREPARING',
+      });
+
+      const body = JSON.stringify({
+        type: 'TRACKING_CHANGED',
+        shippingOrderId: 'BOXTAL-TRACK-3',
+        payload: { trackings: [{ status: 'IN_TRANSIT', trackingNumber: 'TN-45' }] },
+      });
+
+      const response = await request(app)
+        .post('/api/shipping/boxtal/webhook')
+        .set('Content-Type', 'application/json')
+        .set('x-bxt-signature', signBody(body))
+        .send(body);
+
+      expect(response.status).toBe(200);
+
+      const updated = await prisma.order.findUnique({ where: { id: order.id } });
+      expect(updated?.fulfillmentStatus).toBe('SHIPPED');
+      expect(updated?.status).toBe('SHIPPED');
+      expect(updated?.shippedAt).not.toBeNull();
+    });
+  });
+
+  describe('POST /api/admin/orders/:orderId/boxtal-shipment', () => {
+    let adminToken: string;
+
+    beforeEach(async () => {
+      await cleanupDatabase();
+      setBoxtalEnv();
+
+      const adminUser = await createTestUser({
+        email: 'admin-boxtal@example.com',
+        username: 'adminboxtal',
+        isAdmin: true,
+      });
+      adminToken = generateAccessToken({
+        userId: adminUser.id,
+        email: adminUser.email,
+        username: adminUser.username,
+        isAdmin: true,
+      });
+    });
+
+    afterAll(async () => {
+      await cleanupDatabase();
+    });
+
+    const orderAddresses = {
+      shippingMethod: 'COLISSIMO_HOME',
+      shippingAddress: {
+        name: 'Jean Dupont',
+        address: {
+          line1: '5 avenue des Champs',
+          city: 'Paris',
+          postal_code: '75008',
+          country: 'FR',
+        },
+      },
+      billingAddress: { name: 'Jean Dupont', email: 'jean@example.com' },
+    };
+
+    it("crée l'étiquette et passe la commande en PREPARING (pas expédiée)", async () => {
+      stubBoxtalApi({ trackingStatus: null });
+      const order = await createTestOrder(orderAddresses);
+
+      const response = await request(app)
+        .post(`/api/admin/orders/${order.id}/boxtal-shipment`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body.order.boxtalShippingOrderId).toBe('BOXTAL-ADMIN-1');
+      expect(response.body.order.fulfillmentStatus).toBe('PREPARING');
+      expect(response.body.order.status).toBe('CONFIRMED');
+      expect(response.body.order.shippedAt).toBeNull();
+      expect(response.body.order.labelUrl).toBe('https://document.boxtal.test/admin-label.pdf');
+      expect(response.body.order.carrier).toBe('COLISSIMO');
+    });
+
+    it('resynchronise et passe en SHIPPED quand le transporteur a scanné le colis', async () => {
+      stubBoxtalApi({ trackingStatus: 'SHIPPED' });
+      const order = await createTestOrder({
+        ...orderAddresses,
+        boxtalShippingOrderId: 'BOXTAL-ADMIN-1',
+        fulfillmentStatus: 'PREPARING',
+        labelUrl: 'https://document.boxtal.test/admin-label.pdf',
+      });
+
+      const response = await request(app)
+        .post(`/api/admin/orders/${order.id}/boxtal-shipment`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body.order.fulfillmentStatus).toBe('SHIPPED');
+      expect(response.body.order.trackingNumber).toBe('TN-99');
+      expect(response.body.order.shippedAt).not.toBeNull();
+    });
+
+    it('refuse sans configuration Boxtal', async () => {
+      clearBoxtalEnv();
+      const order = await createTestOrder(orderAddresses);
+
+      const response = await request(app)
+        .post(`/api/admin/orders/${order.id}/boxtal-shipment`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({});
+
+      expect(response.status).toBe(502);
+      expect(response.body.code).toBe('BOXTAL_NOT_CONFIGURED');
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,6 +12,7 @@ import promoRoutes from './routes/promo.js';
 import collectionRoutes from './routes/collection.js';
 import tradeOffersRoutes from './routes/trade-offers.js';
 import adminRoutes from './routes/admin.js';
+import shippingRoutes, { boxtalWebhookHandler } from './routes/shipping.js';
 import orderRoutes from './routes/orders.js';
 import contactRoutes from './routes/contact.js';
 import gdprRoutes from './routes/gdpr.js';
@@ -65,6 +66,14 @@ export const createApp = () => {
 
   // Middlewares de sécurité
   app.use(helmetConfig);
+
+  // Webhook Boxtal - corps brut requis pour la signature HMAC (avant express.json)
+  app.post(
+    '/api/shipping/boxtal/webhook',
+    express.raw({ type: 'application/json' }),
+    boxtalWebhookHandler
+  );
+
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));
   app.use(validateInput);
@@ -106,6 +115,9 @@ export const createApp = () => {
 
   // Routes d'administration
   app.use('/api/admin', adminRoutes);
+
+  // Livraison (points relais Boxtal)
+  app.use('/api/shipping', shippingRoutes);
 
   // Routes de suivi commande
   app.use('/api/orders', orderRoutes);

--- a/server/src/config/boxtal.ts
+++ b/server/src/config/boxtal.ts
@@ -1,0 +1,147 @@
+import type { BoxtalOfferType } from './shipping.js';
+
+// Environnements Boxtal API v3 : test = api.boxtal.build, production = api.boxtal.com
+const DEFAULT_BASE_URL = 'https://api.boxtal.build';
+
+export type BoxtalShipper = {
+  company: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  street: string;
+  number?: string;
+  additionalInformation?: string;
+  postalCode: string;
+  city: string;
+  countryIsoCode: string;
+};
+
+export type BoxtalPackageDefaults = {
+  baseWeightGrams: number;
+  perItemWeightGrams: number;
+  lengthCm: number;
+  widthCm: number;
+  heightCm: number;
+};
+
+export type BoxtalConfig = {
+  baseUrl: string;
+  accessKey: string;
+  secretKey: string;
+  offerCodes: Partial<Record<BoxtalOfferType, string>>;
+  shipper: BoxtalShipper | null;
+  packageDefaults: BoxtalPackageDefaults;
+  content: { id: string; description: string };
+  labelType: 'PDF_A4' | 'PDF_10x15';
+  webhookSecret: string | null;
+};
+
+const readEnv = (key: string): string | undefined => {
+  const value = process.env[key];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+};
+
+const readEnvNumber = (key: string, fallback: number): number => {
+  const value = Number(readEnv(key));
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+};
+
+/**
+ * Sépare "12 rue de la Paix" en { number: "12", street: "rue de la Paix" }.
+ * Boxtal attend le numéro de voie dans un champ dédié (optionnel).
+ */
+export function splitStreetLine(line: string): { number?: string; street: string } {
+  const normalized = line.trim().replace(/\s+/g, ' ');
+  const match = normalized.match(/^(\d+[A-Za-z0-9/-]*)\s+(.+)$/);
+  if (!match) {
+    return { street: normalized };
+  }
+  return { number: match[1], street: match[2] };
+}
+
+function buildShipper(): BoxtalShipper | null {
+  const company = readEnv('BOXTAL_SHIPPER_COMPANY');
+  const firstName = readEnv('BOXTAL_SHIPPER_FIRST_NAME');
+  const lastName = readEnv('BOXTAL_SHIPPER_LAST_NAME');
+  const email = readEnv('BOXTAL_SHIPPER_EMAIL');
+  const phone = readEnv('BOXTAL_SHIPPER_PHONE');
+  const addressLine = readEnv('BOXTAL_SHIPPER_ADDRESS');
+  const postalCode = readEnv('BOXTAL_SHIPPER_POSTAL_CODE');
+  const city = readEnv('BOXTAL_SHIPPER_CITY');
+
+  if (
+    !company ||
+    !firstName ||
+    !lastName ||
+    !email ||
+    !phone ||
+    !addressLine ||
+    !postalCode ||
+    !city
+  ) {
+    return null;
+  }
+
+  const { number, street } = splitStreetLine(addressLine);
+
+  return {
+    company,
+    firstName,
+    lastName,
+    email,
+    phone,
+    street,
+    number,
+    additionalInformation: readEnv('BOXTAL_SHIPPER_ADDRESS_2'),
+    postalCode,
+    city,
+    countryIsoCode: (readEnv('BOXTAL_SHIPPER_COUNTRY') || 'FR').toUpperCase(),
+  };
+}
+
+/**
+ * Lit la configuration Boxtal depuis l'environnement.
+ * Retourne null si les clés API ne sont pas définies (fonctionnalité désactivée).
+ */
+export function getBoxtalConfig(): BoxtalConfig | null {
+  const accessKey = readEnv('BOXTAL_ACCESS_KEY');
+  const secretKey = readEnv('BOXTAL_SECRET_KEY');
+  if (!accessKey || !secretKey) {
+    return null;
+  }
+
+  const labelType = readEnv('BOXTAL_LABEL_TYPE') === 'PDF_10x15' ? 'PDF_10x15' : 'PDF_A4';
+
+  return {
+    baseUrl: (readEnv('BOXTAL_API_BASE_URL') || DEFAULT_BASE_URL).replace(/\/$/, ''),
+    accessKey,
+    secretKey,
+    offerCodes: {
+      RELAY: readEnv('BOXTAL_SHIPPING_OFFER_CODE_RELAY'),
+      HOME: readEnv('BOXTAL_SHIPPING_OFFER_CODE_HOME'),
+    },
+    shipper: buildShipper(),
+    packageDefaults: {
+      baseWeightGrams: readEnvNumber('BOXTAL_PACKAGE_BASE_WEIGHT_GRAMS', 150),
+      perItemWeightGrams: readEnvNumber('BOXTAL_PACKAGE_ITEM_WEIGHT_GRAMS', 50),
+      lengthCm: readEnvNumber('BOXTAL_PACKAGE_LENGTH_CM', 24),
+      widthCm: readEnvNumber('BOXTAL_PACKAGE_WIDTH_CM', 18),
+      heightCm: readEnvNumber('BOXTAL_PACKAGE_HEIGHT_CM', 8),
+    },
+    content: {
+      // Catégorie de contenu Boxtal (GET /content-category) — cartes à collectionner
+      id: readEnv('BOXTAL_CONTENT_CATEGORY_ID') || 'content:v1:80100',
+      description:
+        readEnv('BOXTAL_CONTENT_DESCRIPTION') || 'Cartes à collectionner et accessoires TCG',
+    },
+    labelType,
+    webhookSecret: readEnv('BOXTAL_WEBHOOK_SECRET') || null,
+  };
+}
+
+export function isBoxtalConfigured(): boolean {
+  return getBoxtalConfig() !== null;
+}

--- a/server/src/config/shipping.ts
+++ b/server/src/config/shipping.ts
@@ -1,3 +1,5 @@
+export type BoxtalOfferType = 'RELAY' | 'HOME';
+
 export type ShippingMethod = {
   code: string;
   label: string;
@@ -5,24 +7,32 @@ export type ShippingMethod = {
   carrier: string;
   enabled: boolean;
   description?: string;
+  // Livraison via Boxtal : type d'offre (mappe vers BOXTAL_SHIPPING_OFFER_CODE_RELAY / _HOME)
+  boxtalOfferType: BoxtalOfferType;
+  // true si le client doit choisir un point relais au checkout
+  requiresPickupPoint: boolean;
 };
 
 export const SHIPPING_METHODS: ShippingMethod[] = [
   {
     code: 'MONDIAL_RELAY',
-    label: 'Mondial Relay - Point relais',
+    label: 'Livraison en point relais',
     priceCents: 490,
     carrier: 'MONDIAL_RELAY',
     enabled: true,
     description: 'Livraison en point relais (3 à 5 jours)',
+    boxtalOfferType: 'RELAY',
+    requiresPickupPoint: true,
   },
   {
     code: 'COLISSIMO_HOME',
-    label: 'Colissimo - Domicile',
+    label: 'Livraison à domicile',
     priceCents: 790,
     carrier: 'COLISSIMO',
     enabled: true,
     description: 'Livraison à domicile (48h)',
+    boxtalOfferType: 'HOME',
+    requiresPickupPoint: false,
   },
 ];
 

--- a/server/src/config/validateEnv.ts
+++ b/server/src/config/validateEnv.ts
@@ -48,6 +48,16 @@ export function validateEnvOrThrow() {
   ];
 
   const errors = requireEnv(checks);
+
+  // Boxtal (optionnel) : détecter une configuration partielle des clés API
+  const hasBoxtalAccess = !!process.env.BOXTAL_ACCESS_KEY?.trim();
+  const hasBoxtalSecret = !!process.env.BOXTAL_SECRET_KEY?.trim();
+  if (hasBoxtalAccess !== hasBoxtalSecret) {
+    errors.push(
+      'BOXTAL_ACCESS_KEY et BOXTAL_SECRET_KEY doivent être définis ensemble (configuration Boxtal partielle)'
+    );
+  }
+
   if (errors.length === 0) return;
 
   const message = `Configuration invalide (env):\n- ${errors.join('\n- ')}`;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,6 +19,7 @@ import promoRoutes from './routes/promo.js';
 import collectionRoutes from './routes/collection.js';
 import tradeOffersRoutes from './routes/trade-offers.js';
 import adminRoutes from './routes/admin.js';
+import shippingRoutes, { boxtalWebhookHandler } from './routes/shipping.js';
 import twoFactorRoutes from './routes/twoFactor.js';
 import contactRoutes from './routes/contact.js';
 import gdprRoutes from './routes/gdpr.js';
@@ -97,6 +98,13 @@ app.post(
   checkoutWebhookHandler
 );
 
+// Webhook Boxtal - corps brut requis pour vérifier la signature HMAC (x-bxt-signature)
+app.post(
+  '/api/shipping/boxtal/webhook',
+  express.raw({ type: 'application/json' }),
+  boxtalWebhookHandler
+);
+
 // Servir les fichiers uploadés (images produits)
 app.use('/uploads', express.static(path.join(__dirname, '../public/uploads')));
 
@@ -110,10 +118,10 @@ app.use(validateInput);
 app.use(sanitizeInput);
 app.use(injectionProtection);
 
-// Rate limiting global (exclure le webhook Stripe)
+// Rate limiting global (exclure les webhooks Stripe et Boxtal)
 app.use('/api/', (req, res, next) => {
-  // Exempter le webhook Stripe du rate limiting
-  if (req.path === '/checkout/webhook') {
+  // Exempter les webhooks du rate limiting
+  if (req.path === '/checkout/webhook' || req.path === '/shipping/boxtal/webhook') {
     return next();
   }
   apiLimiter(req, res, next);
@@ -167,6 +175,9 @@ app.use('/api/trade-offers', tradeOffersRoutes);
 
 // Routes d'administration
 app.use('/api/admin', adminRoutes);
+
+// Livraison (points relais Boxtal)
+app.use('/api/shipping', shippingRoutes);
 
 // Routes 2FA (Two-Factor Authentication)
 app.use('/api/2fa', twoFactorRoutes);

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -12,8 +12,17 @@ import {
   sendDeliveryConfirmationEmail,
   sendOrderConfirmationEmail,
 } from '../services/email.js';
-import { buildTrackingUrl, generateOrderTrackingToken } from '../utils/tracking.js';
+import { buildTrackingUrl, buildOrderTrackingLink } from '../utils/tracking.js';
 import { audit, auditLog } from '../utils/audit.js';
+import { findShippingMethod } from '../config/shipping.js';
+import {
+  BoxtalApiError,
+  createShippingOrder,
+  getShippingOrderTracking,
+  getShippingLabelUrl,
+  carrierFromOfferCode,
+} from '../services/boxtal.js';
+import { applyBoxtalTrackingUpdate } from '../services/fulfillment.js';
 
 const router = Router();
 
@@ -79,22 +88,6 @@ const addOrderEvent = async (
       createdBy,
     },
   });
-};
-
-const shopBaseUrl = () =>
-  (
-    process.env.SHOP_URL ||
-    process.env.FRONTEND_PUBLIC_URL ||
-    process.env.FRONT_BASE_URL ||
-    process.env.FRONTEND_URL ||
-    ''
-  ).replace(/\/$/, '');
-
-const buildOrderTrackingLink = (orderId: string, customerEmail?: string | null) => {
-  const base = shopBaseUrl();
-  if (!base) return null;
-  const token = generateOrderTrackingToken(orderId, customerEmail);
-  return `${base}/order-tracking/${orderId}?token=${token}`;
 };
 
 const uploadDir = path.join(process.cwd(), 'public/uploads');
@@ -402,6 +395,229 @@ router.post(
         order: updatedOrder,
       });
     } catch {
+      res.status(500).json({
+        error: 'Erreur interne du serveur',
+        code: 'INTERNAL_SERVER_ERROR',
+      });
+    }
+  }
+);
+
+/**
+ * Expédition via Boxtal : crée la commande d'expédition (étiquette) chez
+ * Boxtal, récupère suivi + étiquette, marque la commande expédiée et notifie
+ * le client. Rejouable : si l'expédition Boxtal existe déjà, resynchronise
+ * simplement le suivi et l'étiquette.
+ */
+router.post(
+  '/orders/:orderId/boxtal-shipment',
+  adminWriteLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const { orderId } = req.params;
+
+      const existingOrder = await prisma.order.findUnique({
+        where: { id: orderId },
+        include: {
+          items: true,
+          user: {
+            select: { id: true, email: true, username: true, firstName: true, lastName: true },
+          },
+        },
+      });
+
+      if (!existingOrder) {
+        return res.status(404).json({ error: 'Commande non trouvée', code: 'ORDER_NOT_FOUND' });
+      }
+
+      // Resynchronisation : l'expédition Boxtal existe déjà pour cette commande.
+      // Récupère étiquette + suivi et applique les transitions d'état réelles
+      // (PREPARING → SHIPPED au premier scan transporteur, → DELIVERED ensuite).
+      if (existingOrder.boxtalShippingOrderId) {
+        const [tracking, labelUrl] = await Promise.all([
+          getShippingOrderTracking(existingOrder.boxtalShippingOrderId),
+          getShippingLabelUrl(existingOrder.boxtalShippingOrderId),
+        ]);
+
+        if (labelUrl && labelUrl !== existingOrder.labelUrl) {
+          await prisma.order.update({
+            where: { id: orderId },
+            data: { labelUrl },
+          });
+        }
+
+        await applyBoxtalTrackingUpdate(existingOrder, tracking);
+
+        const updatedOrder = await prisma.order.findUnique({
+          where: { id: orderId },
+          include: {
+            items: true,
+            user: {
+              select: { id: true, email: true, username: true, firstName: true, lastName: true },
+            },
+          },
+        });
+
+        return res.json({
+          message: 'Expédition Boxtal resynchronisée',
+          order: updatedOrder,
+        });
+      }
+
+      if (
+        existingOrder.fulfillmentStatus === FulfillmentStatus.SHIPPED ||
+        existingOrder.fulfillmentStatus === FulfillmentStatus.DELIVERED
+      ) {
+        return res.status(200).json({ message: 'Commande déjà expédiée', order: existingOrder });
+      }
+
+      const shippingAddress = existingOrder.shippingAddress as {
+        name?: string | null;
+        address?: {
+          line1?: string | null;
+          line2?: string | null;
+          city?: string | null;
+          postal_code?: string | null;
+          country?: string | null;
+        } | null;
+      } | null;
+
+      const billingAddress = existingOrder.billingAddress as {
+        name?: string | null;
+        email?: string | null;
+        phone?: string | null;
+      } | null;
+
+      const recipientName = shippingAddress?.name || billingAddress?.name || '';
+      const recipientEmail = billingAddress?.email || existingOrder.user?.email || '';
+      const line1 = shippingAddress?.address?.line1 || '';
+      const postalCode = shippingAddress?.address?.postal_code || '';
+      const city = shippingAddress?.address?.city || '';
+
+      if (!recipientName || !recipientEmail || !line1 || !postalCode || !city) {
+        return res.status(400).json({
+          error: 'Adresse de livraison incomplète sur la commande (nom, email, adresse requis)',
+          code: 'INCOMPLETE_SHIPPING_ADDRESS',
+        });
+      }
+
+      const shippingMethod = findShippingMethod(existingOrder.shippingMethod);
+      const offerType =
+        shippingMethod?.boxtalOfferType ?? (existingOrder.pickupPointCode ? 'RELAY' : 'HOME');
+
+      if (offerType === 'RELAY' && !existingOrder.pickupPointCode) {
+        return res.status(400).json({
+          error: 'Aucun point relais associé à cette commande',
+          code: 'PICKUP_POINT_MISSING',
+        });
+      }
+
+      const itemsCount = existingOrder.items.reduce((sum, item) => sum + item.quantity, 0);
+
+      const shipment = await createShippingOrder({
+        externalId: existingOrder.id,
+        offerType,
+        pickupPointCode: existingOrder.pickupPointCode,
+        recipient: {
+          name: recipientName,
+          email: recipientEmail,
+          phone: billingAddress?.phone,
+          line1,
+          line2: shippingAddress?.address?.line2,
+          postalCode,
+          city,
+          country: shippingAddress?.address?.country,
+        },
+        itemsCount,
+        valueCents: existingOrder.totalCents - (existingOrder.shippingCost ?? 0),
+      });
+
+      // L'id Boxtal est persisté immédiatement : si la suite échoue, le retry
+      // passera par le chemin de resynchronisation (pas de double étiquette).
+      await prisma.order.update({
+        where: { id: orderId },
+        data: { boxtalShippingOrderId: shipment.boxtalShippingOrderId },
+      });
+
+      // Suivi et étiquette peuvent ne pas être immédiatement disponibles ;
+      // le webhook Boxtal complètera dès qu'ils le seront.
+      let tracking = null;
+      let labelUrl: string | null = null;
+      try {
+        [tracking, labelUrl] = await Promise.all([
+          getShippingOrderTracking(shipment.boxtalShippingOrderId),
+          getShippingLabelUrl(shipment.boxtalShippingOrderId),
+        ]);
+      } catch {
+        // Non bloquant : récupérés plus tard via webhook ou resynchronisation
+      }
+
+      const carrier = carrierFromOfferCode(shipment.offerCode);
+
+      // Étiquette créée ≠ colis expédié : la commande passe « en préparation ».
+      // Le passage à « expédiée » (+ email client) se fait au premier scan du
+      // transporteur, via le webhook Boxtal ou une resynchronisation.
+      const preparedOrder = await prisma.order.update({
+        where: { id: orderId },
+        data: {
+          carrier,
+          trackingNumber: tracking?.trackingNumber ?? undefined,
+          trackingUrl: tracking?.trackingUrl ?? undefined,
+          labelUrl: labelUrl ?? undefined,
+          fulfillmentStatus: FulfillmentStatus.PREPARING,
+          events: {
+            create: {
+              type: OrderEventType.PREPARING,
+              message: `Étiquette créée via Boxtal (${shipment.boxtalShippingOrderId}) — colis en préparation`,
+              createdBy: req.user?.userId,
+            },
+          },
+        },
+        include: {
+          items: true,
+          user: {
+            select: { id: true, email: true, username: true, firstName: true, lastName: true },
+          },
+        },
+      });
+
+      auditLog(req, 'ORDER_SHIP', 'order', orderId, {
+        via: 'boxtal',
+        boxtalShippingOrderId: shipment.boxtalShippingOrderId,
+        offerCode: shipment.offerCode,
+      });
+
+      // Si Boxtal indique déjà une prise en charge (rare à la création),
+      // applique immédiatement la transition d'état correspondante.
+      await applyBoxtalTrackingUpdate(preparedOrder, tracking);
+
+      const updatedOrder = await prisma.order.findUnique({
+        where: { id: orderId },
+        include: {
+          items: true,
+          user: {
+            select: { id: true, email: true, username: true, firstName: true, lastName: true },
+          },
+        },
+      });
+
+      res.json({
+        message: 'Étiquette Boxtal créée — commande en préparation',
+        order: updatedOrder,
+      });
+    } catch (err) {
+      if (err instanceof BoxtalApiError) {
+        auditLog(req, 'ORDER_SHIP', 'order', req.params.orderId, {
+          via: 'boxtal',
+          failed: true,
+          status: err.status,
+          code: err.code,
+        });
+        return res.status(err.status >= 500 ? 502 : err.status).json({
+          error: err.message,
+          code: err.code,
+        });
+      }
       res.status(500).json({
         error: 'Erreur interne du serveur',
         code: 'INTERNAL_SERVER_ERROR',

--- a/server/src/routes/checkout.ts
+++ b/server/src/routes/checkout.ts
@@ -8,6 +8,7 @@ import { optionalAuth } from '../middleware/auth.js';
 import { sendOrderConfirmationEmail } from '../services/email.js';
 import { sendGa4Purchase, parseGaClientId, type Ga4PurchaseItem } from '../services/ga4.js';
 import { findShippingMethod } from '../config/shipping.js';
+import { normalizePickupPointInput, type PickupPointInput } from '../validators/pickupPoint.js';
 
 const router = Router();
 
@@ -102,6 +103,7 @@ async function createOrderFromSession(
   )
     ? (session.metadata?.shippingCarrier as Carrier)
     : null;
+  const pickupPoint = parseMetadataPickupPoint(session.metadata ?? null);
 
   const orderItemsData = [];
 
@@ -157,6 +159,8 @@ async function createOrderFromSession(
       shippingMethod: shippingMethodCode ?? undefined,
       shippingCost: shippingPriceCents || undefined,
       carrier: shippingCarrier ?? undefined,
+      pickupPointCode: pickupPoint?.code ?? undefined,
+      pickupPoint: pickupPoint ?? undefined,
       billingAddress: (() => {
         const billing = buildBillingAddress(session.customer_details) as any;
         // Forcer l'email du formulaire si disponible dans les métadonnées
@@ -262,6 +266,7 @@ async function processCompletedCheckoutSession(
     )
       ? (session.metadata?.shippingCarrier as Carrier)
       : null;
+    const pickupPoint = parseMetadataPickupPoint(session.metadata ?? null);
 
     const orderItemsData = [];
 
@@ -323,6 +328,8 @@ async function processCompletedCheckoutSession(
         shippingMethod: shippingMethodCode ?? undefined,
         shippingCost: shippingPriceCents || undefined,
         carrier: shippingCarrier ?? undefined,
+        pickupPointCode: pickupPoint?.code ?? undefined,
+        pickupPoint: pickupPoint ?? undefined,
         totalCents,
         currency,
         paymentMethod,
@@ -610,6 +617,19 @@ router.post(
         });
       }
 
+      // Livraison en point relais : le client doit avoir choisi un point
+      let pickupPoint: PickupPointInput | null = null;
+      if (shippingMethod.requiresPickupPoint) {
+        const pickupValidation = normalizePickupPointInput(req.body.pickupPoint);
+        if (!pickupValidation.ok) {
+          return res.status(400).json({
+            error: pickupValidation.error,
+            code: 'INVALID_PICKUP_POINT',
+          });
+        }
+        pickupPoint = pickupValidation.pickupPoint;
+      }
+
       const totalQuantity = requestedItems.reduce((sum, item) => sum + item.quantity, 0);
       if (totalQuantity > MAX_TOTAL_QUANTITY) {
         return res.status(400).json({
@@ -840,6 +860,17 @@ router.post(
         shippingCity: shipping.city,
         shippingCountry: shipping.country,
         ...(shipping.phone ? { shippingPhone: shipping.phone } : {}),
+        ...(pickupPoint
+          ? {
+              pickupPointCode: pickupPoint.code,
+              pickupPointName: pickupPoint.name,
+              ...(pickupPoint.network ? { pickupPointNetwork: pickupPoint.network } : {}),
+              ...(pickupPoint.line1 ? { pickupPointLine1: pickupPoint.line1 } : {}),
+              pickupPointPostalCode: pickupPoint.postalCode,
+              pickupPointCity: pickupPoint.city,
+              pickupPointCountry: pickupPoint.country,
+            }
+          : {}),
         // Stocker l'email du formulaire pour l'utiliser dans l'email de confirmation
         ...(req.body.customerEmail ? { customerEmail: req.body.customerEmail } : {}),
       };
@@ -1143,6 +1174,22 @@ router.get('/verify-session/:sessionId', optionalAuth, async (req, res) => {
     });
   }
 });
+
+// Relit le point relais depuis les métadonnées Stripe (écrites par create-session)
+const parseMetadataPickupPoint = (
+  metadata: Stripe.Metadata | null | undefined
+): (PickupPointInput & { line1?: string }) | null => {
+  if (!metadata?.pickupPointCode) return null;
+  return {
+    code: metadata.pickupPointCode,
+    name: metadata.pickupPointName || metadata.pickupPointCode,
+    network: metadata.pickupPointNetwork || undefined,
+    line1: metadata.pickupPointLine1 || undefined,
+    postalCode: metadata.pickupPointPostalCode || '',
+    city: metadata.pickupPointCity || '',
+    country: metadata.pickupPointCountry || 'FR',
+  };
+};
 
 const parseMetadataItems = (metadata: Stripe.Metadata | null | undefined): CheckoutItemInput[] => {
   if (!metadata) return [];

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -14,6 +14,7 @@ const toPublicTrackingOrderDto = (order: any) => ({
   carrier: order.carrier ?? null,
   trackingNumber: order.trackingNumber ?? null,
   trackingUrl: order.trackingUrl ?? null,
+  pickupPoint: order.pickupPoint ?? null,
   shippedAt: order.shippedAt ?? null,
   deliveredAt: order.deliveredAt ?? null,
   items: (order.items || []).map((it: any) => ({

--- a/server/src/routes/shipping.ts
+++ b/server/src/routes/shipping.ts
@@ -1,0 +1,257 @@
+import { Router, type Request, type Response } from 'express';
+import { query, validationResult } from 'express-validator';
+import rateLimit from 'express-rate-limit';
+import crypto from 'crypto';
+import prisma from '../lib/prisma.js';
+import logger from '../utils/logger.js';
+import { getBoxtalConfig } from '../config/boxtal.js';
+import { getEnabledShippingMethods } from '../config/shipping.js';
+import { BoxtalApiError, searchParcelPoints } from '../services/boxtal.js';
+import { applyBoxtalTrackingUpdate } from '../services/fulfillment.js';
+
+const router = Router();
+
+/**
+ * Rate limiter dédié à la recherche de points relais (appel API Boxtal externe)
+ */
+const parcelPointLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  message: {
+    error: 'Trop de recherches de points relais, veuillez réessayer plus tard',
+    code: 'RATE_LIMIT_EXCEEDED',
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// Liste des modes de livraison actifs (source de vérité côté serveur)
+router.get('/methods', (_req: Request, res: Response) => {
+  res.json({ data: getEnabledShippingMethods() });
+});
+
+// Recherche de points relais proches d'une adresse (proxy Boxtal — les clés
+// API ne sont jamais exposées au frontend)
+router.get(
+  '/parcel-points',
+  parcelPointLimiter,
+  [
+    query('postalCode')
+      .isString()
+      .trim()
+      .matches(/^[A-Za-z0-9 -]{2,12}$/)
+      .withMessage('Code postal invalide'),
+    query('city').optional().isString().trim().isLength({ max: 100 }).withMessage('Ville invalide'),
+    query('country')
+      .optional()
+      .isString()
+      .trim()
+      .matches(/^[A-Za-z]{2}$/)
+      .withMessage('Pays invalide (code ISO 2 lettres)'),
+    query('street')
+      .optional()
+      .isString()
+      .trim()
+      .isLength({ max: 250 })
+      .withMessage('Adresse invalide'),
+  ],
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Paramètres invalides',
+          details: errors.array(),
+        },
+      });
+    }
+
+    try {
+      const points = await searchParcelPoints({
+        postalCode: String(req.query.postalCode),
+        city: req.query.city ? String(req.query.city) : undefined,
+        countryIsoCode: req.query.country ? String(req.query.country) : 'FR',
+        street: req.query.street ? String(req.query.street) : undefined,
+      });
+
+      res.json({ data: points });
+    } catch (err) {
+      if (err instanceof BoxtalApiError) {
+        logger.warn('Recherche de points relais échouée', {
+          status: err.status,
+          code: err.code,
+          detail: err.detail,
+        });
+        const status = err.status === 503 ? 503 : 502;
+        return res.status(status).json({
+          error: {
+            code: err.code,
+            message:
+              err.code === 'BOXTAL_NOT_CONFIGURED'
+                ? 'La recherche de points relais est indisponible'
+                : 'La recherche de points relais a échoué, veuillez réessayer',
+          },
+        });
+      }
+      logger.error('Erreur inattendue lors de la recherche de points relais', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      res.status(500).json({
+        error: { code: 'INTERNAL_SERVER_ERROR', message: 'Erreur interne du serveur' },
+      });
+    }
+  }
+);
+
+// ============================================================================
+// WEBHOOK BOXTAL
+// ============================================================================
+
+const timingSafeCompare = (a: string, b: string): boolean => {
+  const bufferA = Buffer.from(a);
+  const bufferB = Buffer.from(b);
+  return bufferA.length === bufferB.length && crypto.timingSafeEqual(bufferA, bufferB);
+};
+
+/**
+ * Vérifie l'en-tête x-bxt-signature : HMAC SHA256 du corps JSON brut, encodé
+ * avec la clé de validation fournie lors de la souscription au webhook.
+ * Les encodages hex et base64 sont acceptés (non précisé par la doc Boxtal).
+ */
+export function verifyBoxtalSignature(
+  rawBody: Buffer | string,
+  signature: string | undefined,
+  secret: string
+): boolean {
+  if (!signature) return false;
+  if (!Buffer.isBuffer(rawBody) && typeof rawBody !== 'string') return false;
+  const hmac = crypto.createHmac('sha256', secret).update(rawBody);
+  const digest = hmac.digest();
+  return (
+    timingSafeCompare(signature, digest.toString('hex')) ||
+    timingSafeCompare(signature, digest.toString('base64'))
+  );
+}
+
+type BoxtalWebhookEvent = {
+  id?: string;
+  type?: string;
+  shippingOrderId?: string;
+  shipmentExternalId?: string;
+  payload?: {
+    trackings?: Array<{
+      status?: string;
+      trackingNumber?: string;
+      packageTrackingUrl?: string;
+    }>;
+    documents?: Array<{ url?: string; type?: string }>;
+  };
+};
+
+async function findOrderForEvent(event: BoxtalWebhookEvent) {
+  const include = {
+    items: true,
+    user: { select: { email: true } },
+  } as const;
+
+  if (event.shippingOrderId) {
+    const order = await prisma.order.findUnique({
+      where: { boxtalShippingOrderId: event.shippingOrderId },
+      include,
+    });
+    if (order) return order;
+  }
+  if (event.shipmentExternalId) {
+    // externalId envoyé à Boxtal = id interne de la commande
+    return prisma.order.findUnique({ where: { id: event.shipmentExternalId }, include });
+  }
+  return null;
+}
+
+type OrderForWebhook = NonNullable<Awaited<ReturnType<typeof findOrderForEvent>>>;
+
+async function handleTrackingChanged(order: OrderForWebhook, event: BoxtalWebhookEvent) {
+  const tracking = (event.payload?.trackings || []).find(
+    (t) => t && (t.trackingNumber || t.status)
+  );
+  if (!tracking) return;
+
+  // Transitions d'état + emails (expédiée / livrée) gérés par le service partagé
+  await applyBoxtalTrackingUpdate(order, {
+    status: tracking.status,
+    trackingNumber: tracking.trackingNumber,
+    trackingUrl: tracking.packageTrackingUrl,
+  });
+}
+
+async function handleDocumentCreated(order: OrderForWebhook, event: BoxtalWebhookEvent) {
+  const documents = event.payload?.documents || [];
+  const label =
+    documents.find((doc) => doc && doc.type === 'LABEL' && doc.url) ||
+    documents.find((doc) => doc && doc.url);
+  if (!label?.url || label.url === order.labelUrl) return;
+
+  await prisma.order.update({
+    where: { id: order.id },
+    data: { labelUrl: label.url },
+  });
+}
+
+/**
+ * Handler du webhook Boxtal — monté dans index.ts avec express.raw (le corps
+ * brut est nécessaire pour vérifier la signature HMAC). Doit répondre en
+ * moins de 2 secondes, sinon Boxtal rejoue l'événement.
+ */
+export const boxtalWebhookHandler = async (req: Request, res: Response) => {
+  const config = getBoxtalConfig();
+  if (!config?.webhookSecret) {
+    return res.status(503).json({ error: 'Webhook Boxtal non configuré' });
+  }
+
+  const rawBody = (req as unknown as { body: Buffer }).body;
+  const signature = req.headers['x-bxt-signature'];
+
+  if (
+    typeof signature !== 'string' ||
+    !verifyBoxtalSignature(rawBody, signature, config.webhookSecret)
+  ) {
+    logger.warn('Webhook Boxtal : signature invalide');
+    return res.status(401).json({ error: 'Signature invalide' });
+  }
+
+  let event: BoxtalWebhookEvent;
+  try {
+    event = JSON.parse(rawBody.toString('utf8'));
+  } catch {
+    return res.status(400).json({ error: 'Corps JSON invalide' });
+  }
+
+  try {
+    const order = await findOrderForEvent(event);
+    if (!order) {
+      // 200 pour éviter les rejeux : l'événement ne concerne aucune commande connue
+      logger.warn('Webhook Boxtal : commande introuvable', {
+        type: event.type,
+        shippingOrderId: event.shippingOrderId,
+        shipmentExternalId: event.shipmentExternalId,
+      });
+      return res.status(200).json({ received: true });
+    }
+
+    if (event.type === 'TRACKING_CHANGED') {
+      await handleTrackingChanged(order, event);
+    } else if (event.type === 'DOCUMENT_CREATED') {
+      await handleDocumentCreated(order, event);
+    }
+
+    res.status(200).json({ received: true });
+  } catch (err) {
+    logger.error('Webhook Boxtal : erreur de traitement', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    res.status(500).json({ error: 'Erreur de traitement' });
+  }
+};
+
+export default router;

--- a/server/src/services/boxtal.ts
+++ b/server/src/services/boxtal.ts
@@ -1,0 +1,538 @@
+import { Carrier, FulfillmentStatus } from '@prisma/client';
+import { getBoxtalConfig, splitStreetLine, type BoxtalConfig } from '../config/boxtal.js';
+import type { BoxtalOfferType } from '../config/shipping.js';
+import logger from '../utils/logger.js';
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export class BoxtalApiError extends Error {
+  status: number;
+  code: string;
+  detail?: unknown;
+
+  constructor(message: string, status: number, code = 'BOXTAL_ERROR', detail?: unknown) {
+    super(message);
+    this.name = 'BoxtalApiError';
+    this.status = status;
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const asString = (value: unknown): string | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+};
+
+const asNumber = (value: unknown): number | undefined => {
+  const num = typeof value === 'string' ? Number(value) : value;
+  return typeof num === 'number' && Number.isFinite(num) ? num : undefined;
+};
+
+function requireConfig(): BoxtalConfig {
+  const config = getBoxtalConfig();
+  if (!config) {
+    throw new BoxtalApiError(
+      'Boxtal non configuré (BOXTAL_ACCESS_KEY / BOXTAL_SECRET_KEY manquants)',
+      503,
+      'BOXTAL_NOT_CONFIGURED'
+    );
+  }
+  return config;
+}
+
+/**
+ * Appel HTTP vers l'API Boxtal v3, authentifié en Basic (officiellement
+ * supporté sur tous les endpoints — pas de gestion de token à maintenir).
+ */
+async function boxtalFetch(
+  path: string,
+  init: { method?: string; body?: unknown } = {},
+  config = requireConfig()
+): Promise<unknown> {
+  const basic = Buffer.from(`${config.accessKey}:${config.secretKey}`).toString('base64');
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${config.baseUrl}${path}`, {
+      method: init.method || 'GET',
+      headers: {
+        Authorization: `Basic ${basic}`,
+        Accept: 'application/json',
+        ...(init.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    throw new BoxtalApiError(
+      'Boxtal injoignable',
+      503,
+      'BOXTAL_UNREACHABLE',
+      err instanceof Error ? err.message : err
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const text = await response.text();
+  let payload: unknown = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = text;
+  }
+
+  if (!response.ok) {
+    const message = isRecord(payload)
+      ? asString((payload.messages as any)?.[0]?.text) || `Erreur Boxtal (${response.status})`
+      : `Erreur Boxtal (${response.status})`;
+    throw new BoxtalApiError(message, response.status, 'BOXTAL_API_ERROR', payload);
+  }
+
+  return payload;
+}
+
+// ============================================================================
+// POINTS RELAIS
+// ============================================================================
+
+export type ParcelPointOpeningPeriod = { open: string; close: string };
+
+export type ParcelPoint = {
+  code: string;
+  name: string;
+  networks: string[];
+  address: {
+    number?: string;
+    street?: string;
+    postalCode?: string;
+    city?: string;
+    country?: string;
+  };
+  distanceMeters?: number;
+  latitude?: number;
+  longitude?: number;
+  openingDays?: Record<string, ParcelPointOpeningPeriod[]>;
+};
+
+function normalizeParcelPoint(candidate: unknown): ParcelPoint | null {
+  if (!isRecord(candidate)) return null;
+  // L'API renvoie « parcelPoint » (constaté en test) ; « parcelpoint » figure
+  // dans certaines intégrations — les deux graphies sont acceptées.
+  const nested = candidate.parcelPoint ?? candidate.parcelpoint;
+  const record = isRecord(nested) ? nested : candidate;
+  const code = asString(record.code);
+  const name = asString(record.name);
+  if (!code || !name) return null;
+
+  const location = isRecord(record.location) ? record.location : {};
+  const position = isRecord(location.position) ? location.position : {};
+
+  const openingDays: Record<string, ParcelPointOpeningPeriod[]> = {};
+  if (isRecord(record.openingDays)) {
+    for (const [day, periods] of Object.entries(record.openingDays)) {
+      if (!Array.isArray(periods)) continue;
+      openingDays[day] = periods
+        .map((p) =>
+          isRecord(p)
+            ? { open: asString(p.openingTime) || '', close: asString(p.closingTime) || '' }
+            : null
+        )
+        .filter(
+          (p): p is ParcelPointOpeningPeriod => p !== null && p.open !== '' && p.close !== ''
+        );
+    }
+  }
+
+  return {
+    code,
+    name,
+    networks: Array.isArray(record.compatibleNetworks)
+      ? record.compatibleNetworks.map((n) => asString(n)).filter((n): n is string => Boolean(n))
+      : [],
+    address: {
+      number: asString(location.number),
+      street: asString(location.street),
+      postalCode: asString(location.postalCode),
+      city: asString(location.city),
+      country: asString(location.countryIsoCode),
+    },
+    distanceMeters: asNumber((candidate as Record<string, unknown>).distanceFromSearchLocation),
+    latitude: asNumber(position.latitude),
+    longitude: asNumber(position.longitude),
+    openingDays: Object.keys(openingDays).length > 0 ? openingDays : undefined,
+  };
+}
+
+export type ParcelPointSearchParams = {
+  postalCode: string;
+  city?: string;
+  countryIsoCode?: string;
+  street?: string;
+};
+
+/**
+ * Recherche les points relais proches d'une adresse pour l'offre relais
+ * configurée (GET /shipping/v3.2/parcel-point-by-shipping-offer).
+ */
+export async function searchParcelPoints(params: ParcelPointSearchParams): Promise<ParcelPoint[]> {
+  const config = requireConfig();
+  const offerCode = config.offerCodes.RELAY;
+  if (!offerCode) {
+    throw new BoxtalApiError(
+      'Offre relais non configurée (BOXTAL_SHIPPING_OFFER_CODE_RELAY manquant)',
+      503,
+      'BOXTAL_NOT_CONFIGURED'
+    );
+  }
+
+  const query = new URLSearchParams({
+    operationType: 'ARRIVAL',
+    shippingOfferCode: offerCode,
+    countryIsoCode: (params.countryIsoCode || 'FR').toUpperCase(),
+    postalCode: params.postalCode,
+  });
+  if (params.city) query.set('city', params.city);
+  if (params.street) {
+    const { number, street } = splitStreetLine(params.street);
+    query.set('street', street);
+    if (number) query.set('number', number);
+  }
+
+  const payload = await boxtalFetch(
+    `/shipping/v3.2/parcel-point-by-shipping-offer?${query.toString()}`,
+    {},
+    config
+  );
+
+  const content = isRecord(payload) && Array.isArray(payload.content) ? payload.content : [];
+  return content
+    .map((candidate) => normalizeParcelPoint(candidate))
+    .filter((point): point is ParcelPoint => point !== null);
+}
+
+// ============================================================================
+// COMMANDES D'EXPÉDITION
+// ============================================================================
+
+export type ShipmentRecipient = {
+  name: string;
+  email: string;
+  phone?: string | null;
+  line1: string;
+  line2?: string | null;
+  postalCode: string;
+  city: string;
+  country?: string | null;
+};
+
+export type CreateShipmentParams = {
+  externalId: string;
+  offerType: BoxtalOfferType;
+  recipient: ShipmentRecipient;
+  pickupPointCode?: string | null;
+  itemsCount: number;
+  valueCents: number;
+};
+
+export type BoxtalShipmentResult = {
+  boxtalShippingOrderId: string;
+  status?: string;
+  offerCode: string;
+};
+
+function splitFullName(name: string): { firstName: string; lastName: string } {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length <= 1) {
+    return { firstName: parts[0] || 'Client', lastName: 'BoulevardTCG' };
+  }
+  return {
+    firstName: parts.slice(0, -1).join(' '),
+    lastName: parts[parts.length - 1],
+  };
+}
+
+/** Normalise un téléphone au format international attendu par Boxtal (+33...). */
+export function normalizePhone(phone: string, country = 'FR'): string {
+  const digits = phone.replace(/\D/g, '');
+  if (!digits) return phone;
+  if (phone.trim().startsWith('+')) return `+${digits}`;
+  if (country === 'FR') {
+    if (digits.startsWith('33')) return `+${digits}`;
+    if (digits.startsWith('0')) return `+33${digits.slice(1)}`;
+    return `+33${digits}`;
+  }
+  return `+${digits}`;
+}
+
+const COUNTRY_ALIASES: Record<string, string> = {
+  FRANCE: 'FR',
+  BELGIQUE: 'BE',
+  BELGIUM: 'BE',
+  LUXEMBOURG: 'LU',
+  SUISSE: 'CH',
+  SWITZERLAND: 'CH',
+  ALLEMAGNE: 'DE',
+  GERMANY: 'DE',
+  ESPAGNE: 'ES',
+  SPAIN: 'ES',
+  ITALIE: 'IT',
+  ITALY: 'IT',
+  NETHERLANDS: 'NL',
+  'PAYS-BAS': 'NL',
+};
+
+export function normalizeCountryIso2(country: string | null | undefined): string {
+  const upper = (country || '').trim().toUpperCase();
+  if (!upper) return 'FR';
+  if (COUNTRY_ALIASES[upper]) return COUNTRY_ALIASES[upper];
+  return upper.length === 2 ? upper : upper.slice(0, 2);
+}
+
+/**
+ * Crée une commande d'expédition Boxtal (POST /shipping/v3.1/shipping-order).
+ * Le poids est estimé depuis les valeurs par défaut (base + poids par article).
+ */
+export async function createShippingOrder(
+  params: CreateShipmentParams
+): Promise<BoxtalShipmentResult> {
+  const config = requireConfig();
+  const offerCode = config.offerCodes[params.offerType];
+  if (!offerCode) {
+    throw new BoxtalApiError(
+      `Offre ${params.offerType} non configurée (BOXTAL_SHIPPING_OFFER_CODE_${params.offerType} manquant)`,
+      503,
+      'BOXTAL_NOT_CONFIGURED'
+    );
+  }
+  if (!config.shipper) {
+    throw new BoxtalApiError(
+      'Expéditeur non configuré (variables BOXTAL_SHIPPER_* manquantes)',
+      503,
+      'BOXTAL_NOT_CONFIGURED'
+    );
+  }
+  if (params.offerType === 'RELAY' && !params.pickupPointCode) {
+    throw new BoxtalApiError(
+      'Point relais manquant pour une expédition en relais',
+      400,
+      'PICKUP_POINT_REQUIRED'
+    );
+  }
+
+  const shipper = config.shipper;
+  const recipientCountry = normalizeCountryIso2(params.recipient.country);
+  const { firstName, lastName } = splitFullName(params.recipient.name);
+  const { number, street } = splitStreetLine(params.recipient.line1);
+
+  const { baseWeightGrams, perItemWeightGrams, lengthCm, widthCm, heightCm } =
+    config.packageDefaults;
+  const weightKg = (baseWeightGrams + Math.max(0, params.itemsCount) * perItemWeightGrams) / 1000;
+
+  const fromAddress = {
+    type: 'BUSINESS' as const,
+    contact: {
+      firstName: shipper.firstName,
+      lastName: shipper.lastName,
+      email: shipper.email,
+      phone: normalizePhone(shipper.phone, shipper.countryIsoCode),
+      company: shipper.company,
+    },
+    location: {
+      street: shipper.street,
+      number: shipper.number,
+      postalCode: shipper.postalCode,
+      city: shipper.city,
+      countryIsoCode: shipper.countryIsoCode,
+    },
+    additionalInformation: shipper.additionalInformation,
+  };
+
+  const requestBody = {
+    shippingOfferCode: offerCode,
+    labelType: config.labelType,
+    shipment: {
+      externalId: params.externalId,
+      content: config.content,
+      fromAddress,
+      returnAddress: fromAddress,
+      toAddress: {
+        type: 'RESIDENTIAL' as const,
+        contact: {
+          firstName,
+          lastName,
+          email: params.recipient.email,
+          phone: normalizePhone(params.recipient.phone || shipper.phone, recipientCountry),
+        },
+        location: {
+          street,
+          number,
+          postalCode: params.recipient.postalCode,
+          city: params.recipient.city,
+          countryIsoCode: recipientCountry,
+        },
+        additionalInformation: params.recipient.line2 || undefined,
+      },
+      packages: [
+        {
+          type: 'PARCEL' as const,
+          weight: Number(weightKg.toFixed(3)),
+          length: Math.round(lengthCm),
+          width: Math.round(widthCm),
+          height: Math.round(heightCm),
+          value: {
+            value: Number(Math.max(0.01, params.valueCents / 100).toFixed(2)),
+            currency: 'EUR' as const,
+          },
+          content: config.content,
+          externalId: params.externalId,
+        },
+      ],
+      ...(params.pickupPointCode ? { pickupPointCode: params.pickupPointCode } : {}),
+    },
+  };
+
+  const payload = await boxtalFetch('/shipping/v3.1/shipping-order', {
+    method: 'POST',
+    body: requestBody,
+  });
+
+  const content = isRecord(payload) && isRecord(payload.content) ? payload.content : {};
+  const boxtalShippingOrderId = asString(content.id);
+  if (!boxtalShippingOrderId) {
+    logger.error('Boxtal: réponse de création sans id', { payload });
+    throw new BoxtalApiError(
+      "Réponse Boxtal invalide (id de commande d'expédition manquant)",
+      502,
+      'BOXTAL_INVALID_RESPONSE',
+      payload
+    );
+  }
+
+  return {
+    boxtalShippingOrderId,
+    status: asString(content.status),
+    offerCode,
+  };
+}
+
+/**
+ * Annule une commande d'expédition Boxtal (DELETE /shipping/v3.1/shipping-order/{id}).
+ * Possible tant que le transporteur n'a pas pris en charge le colis.
+ */
+export async function cancelShippingOrder(boxtalShippingOrderId: string): Promise<void> {
+  await boxtalFetch(`/shipping/v3.1/shipping-order/${encodeURIComponent(boxtalShippingOrderId)}`, {
+    method: 'DELETE',
+  });
+}
+
+// ============================================================================
+// SUIVI ET DOCUMENTS
+// ============================================================================
+
+export type BoxtalTracking = {
+  status?: string;
+  trackingNumber?: string;
+  trackingUrl?: string;
+};
+
+/**
+ * Récupère le suivi d'une commande d'expédition.
+ * Retourne null si le suivi n'est pas encore disponible (422 côté Boxtal).
+ */
+export async function getShippingOrderTracking(
+  boxtalShippingOrderId: string
+): Promise<BoxtalTracking | null> {
+  let payload: unknown;
+  try {
+    payload = await boxtalFetch(
+      `/shipping/v3.1/shipping-order/${encodeURIComponent(boxtalShippingOrderId)}/tracking`
+    );
+  } catch (err) {
+    if (err instanceof BoxtalApiError && err.status === 422) return null;
+    throw err;
+  }
+
+  const content = isRecord(payload) && Array.isArray(payload.content) ? payload.content : [];
+  const primary = content.find(
+    (item) => isRecord(item) && (asString(item.trackingNumber) || asString(item.packageTrackingUrl))
+  );
+  if (!isRecord(primary)) return null;
+
+  return {
+    status: asString(primary.status),
+    trackingNumber: asString(primary.trackingNumber),
+    trackingUrl: asString(primary.packageTrackingUrl),
+  };
+}
+
+/**
+ * Récupère l'URL de l'étiquette PDF (document LABEL).
+ * Retourne null si le document n'est pas encore généré (422 côté Boxtal).
+ */
+export async function getShippingLabelUrl(boxtalShippingOrderId: string): Promise<string | null> {
+  let payload: unknown;
+  try {
+    payload = await boxtalFetch(
+      `/shipping/v3.1/shipping-order/${encodeURIComponent(boxtalShippingOrderId)}/shipping-document`
+    );
+  } catch (err) {
+    if (err instanceof BoxtalApiError && err.status === 422) return null;
+    throw err;
+  }
+
+  const content = isRecord(payload) && Array.isArray(payload.content) ? payload.content : [];
+  const documents = content.filter(isRecord);
+  const label =
+    documents.find((doc) => asString(doc.type) === 'LABEL' && asString(doc.url)) ||
+    documents.find((doc) => asString(doc.url));
+  return label ? (asString(label.url) ?? null) : null;
+}
+
+// ============================================================================
+// MAPPINGS
+// ============================================================================
+
+// Préfixe opérateur des codes d'offre Boxtal (ex: "MONR-CpourToi" → MONR)
+const OFFER_PREFIX_TO_CARRIER: Record<string, Carrier> = {
+  MONR: Carrier.MONDIAL_RELAY,
+  POFR: Carrier.COLISSIMO,
+  CHRP: Carrier.CHRONOPOST,
+  UPSE: Carrier.UPS,
+  DHLE: Carrier.DHL,
+  FEDX: Carrier.FEDEX,
+};
+
+export function carrierFromOfferCode(offerCode: string | null | undefined): Carrier {
+  const prefix = (offerCode || '').split('-')[0]?.trim().toUpperCase();
+  return (prefix && OFFER_PREFIX_TO_CARRIER[prefix]) || Carrier.OTHER;
+}
+
+/**
+ * Mappe un statut de suivi Boxtal vers le statut de fulfillment interne.
+ * Retourne null quand le statut n'implique aucune transition.
+ */
+export function fulfillmentStatusFromTracking(
+  trackingStatus: string | null | undefined
+): FulfillmentStatus | null {
+  switch ((trackingStatus || '').toUpperCase()) {
+    case 'SHIPPED':
+    case 'IN_TRANSIT':
+    case 'OUT_FOR_DELIVERY':
+    case 'FAILED_ATTEMPT':
+    case 'REACHED_DELIVERY_PICKUP_POINT':
+      return FulfillmentStatus.SHIPPED;
+    case 'DELIVERED':
+      return FulfillmentStatus.DELIVERED;
+    default:
+      return null;
+  }
+}

--- a/server/src/services/email.ts
+++ b/server/src/services/email.ts
@@ -185,6 +185,12 @@ interface OrderDataForEmail {
   trackingUrl?: string;
   orderTrackingUrl?: string;
   carrier?: string;
+  pickupPoint?: {
+    name?: string;
+    line1?: string;
+    postalCode?: string;
+    city?: string;
+  } | null;
 }
 
 function formatPrice(cents: number): string {
@@ -407,6 +413,21 @@ function shippingNotificationTemplate(order: OrderDataForEmail, customerEmail: s
         ${generateItemsTable(order.items)}
       </div>
       
+      ${
+        order.pickupPoint
+          ? `
+      <div style="margin-top: 30px; padding-top: 30px; border-top: 2px solid #e5e7eb;">
+        <h3 style="color: #1f2937; margin-bottom: 15px; font-size: 18px;">🏪 Votre point relais</h3>
+        <div class="address-box" style="background: #f9fafb; padding: 15px; border-radius: 8px;">
+          ${order.pickupPoint.name ? `<strong style="font-size: 16px;">${escapeHtml(order.pickupPoint.name)}</strong><br>` : ''}
+          ${order.pickupPoint.line1 ? `${escapeHtml(order.pickupPoint.line1)}<br>` : ''}
+          ${escapeHtml(order.pickupPoint.postalCode)} ${escapeHtml(order.pickupPoint.city)}
+        </div>
+        <p style="margin: 10px 0 0 0; color: #6b7280; font-size: 14px;">Pensez à vous munir d'une pièce d'identité pour retirer votre colis.</p>
+      </div>
+      `
+          : ''
+      }
       ${
         order.shippingAddress
           ? `

--- a/server/src/services/fulfillment.ts
+++ b/server/src/services/fulfillment.ts
@@ -1,0 +1,115 @@
+import { FulfillmentStatus, OrderStatus, OrderEventType, Prisma } from '@prisma/client';
+import prisma from '../lib/prisma.js';
+import { fulfillmentStatusFromTracking, type BoxtalTracking } from './boxtal.js';
+import { sendShippingNotificationEmail, sendDeliveryConfirmationEmail } from './email.js';
+import { buildOrderTrackingLink } from '../utils/tracking.js';
+
+const orderInclude = {
+  items: true,
+  user: { select: { email: true } },
+} satisfies Prisma.OrderInclude;
+
+type OrderForFulfillment = Prisma.OrderGetPayload<{ include: typeof orderInclude }>;
+
+const customerEmailOf = (order: OrderForFulfillment): string | null =>
+  ((order.billingAddress as { email?: string } | null)?.email || order.user?.email) ?? null;
+
+const orderEmailData = (order: OrderForFulfillment) => ({
+  orderNumber: order.orderNumber,
+  totalCents: order.totalCents,
+  currency: order.currency,
+  items: order.items.map((item) => ({
+    productName: item.productName,
+    variantName: item.variantName,
+    imageUrl: item.imageUrl,
+    quantity: item.quantity,
+    unitPriceCents: item.unitPriceCents,
+    totalPriceCents: item.totalPriceCents,
+  })),
+  shippingAddress: order.shippingAddress as any,
+  billingAddress: order.billingAddress as any,
+  pickupPoint: (order.pickupPoint as any) ?? undefined,
+});
+
+/**
+ * Applique un état de suivi Boxtal à une commande : met à jour le numéro et
+ * l'URL de suivi, et fait progresser le statut selon la réalité transporteur.
+ *
+ * Cycle : étiquette créée = PREPARING (géré côté admin) → premier scan
+ * transporteur (SHIPPED/IN_TRANSIT/...) = SHIPPED + email d'expédition →
+ * DELIVERED = livrée + email de livraison. Idempotent : rejouable sans
+ * double transition ni double email.
+ */
+export async function applyBoxtalTrackingUpdate(
+  order: OrderForFulfillment,
+  tracking: BoxtalTracking | null | undefined
+): Promise<OrderForFulfillment> {
+  if (!tracking) return order;
+
+  const data: Prisma.OrderUpdateInput = {};
+
+  if (tracking.trackingNumber && tracking.trackingNumber !== order.trackingNumber) {
+    data.trackingNumber = tracking.trackingNumber;
+  }
+  if (tracking.trackingUrl && tracking.trackingUrl !== order.trackingUrl) {
+    data.trackingUrl = tracking.trackingUrl;
+  }
+
+  const nextFulfillment = fulfillmentStatusFromTracking(tracking.status);
+  const alreadyDelivered = order.fulfillmentStatus === FulfillmentStatus.DELIVERED;
+  const alreadyShipped = order.fulfillmentStatus === FulfillmentStatus.SHIPPED || alreadyDelivered;
+
+  let transition: 'SHIPPED' | 'DELIVERED' | null = null;
+
+  if (nextFulfillment === FulfillmentStatus.SHIPPED && !alreadyShipped) {
+    transition = 'SHIPPED';
+    data.fulfillmentStatus = FulfillmentStatus.SHIPPED;
+    data.status = OrderStatus.SHIPPED;
+    data.shippedAt = order.shippedAt ?? new Date();
+    data.events = {
+      create: {
+        type: OrderEventType.SHIPPED,
+        message: `Colis pris en charge par le transporteur (suivi Boxtal : ${tracking.status})`,
+      },
+    };
+  } else if (nextFulfillment === FulfillmentStatus.DELIVERED && !alreadyDelivered) {
+    transition = 'DELIVERED';
+    data.fulfillmentStatus = FulfillmentStatus.DELIVERED;
+    data.status = OrderStatus.DELIVERED;
+    data.deliveredAt = order.deliveredAt ?? new Date();
+    if (!order.shippedAt) data.shippedAt = new Date();
+    data.events = {
+      create: {
+        type: OrderEventType.DELIVERED,
+        message: 'Colis livré (suivi Boxtal)',
+      },
+    };
+  }
+
+  if (Object.keys(data).length === 0) return order;
+
+  const updatedOrder = await prisma.order.update({
+    where: { id: order.id },
+    data,
+    include: orderInclude,
+  });
+
+  const customerEmail = customerEmailOf(updatedOrder);
+  if (customerEmail && transition === 'SHIPPED') {
+    const orderTrackingUrl = buildOrderTrackingLink(updatedOrder.id, customerEmail);
+    sendShippingNotificationEmail(
+      {
+        ...orderEmailData(updatedOrder),
+        trackingNumber: updatedOrder.trackingNumber ?? undefined,
+        trackingUrl: updatedOrder.trackingUrl ?? undefined,
+        orderTrackingUrl: orderTrackingUrl ?? undefined,
+        carrier: updatedOrder.carrier ?? undefined,
+      },
+      customerEmail
+    ).catch(() => {});
+  } else if (customerEmail && transition === 'DELIVERED') {
+    sendDeliveryConfirmationEmail(orderEmailData(updatedOrder), customerEmail).catch(() => {});
+  }
+
+  return updatedOrder;
+}

--- a/server/src/utils/tracking.ts
+++ b/server/src/utils/tracking.ts
@@ -33,6 +33,23 @@ export function buildTrackingUrl(
   return `${baseUrl}${encodeURIComponent(trackingNumber)}`;
 }
 
+export const shopBaseUrl = () =>
+  (
+    process.env.SHOP_URL ||
+    process.env.FRONTEND_PUBLIC_URL ||
+    process.env.FRONT_BASE_URL ||
+    process.env.FRONTEND_URL ||
+    ''
+  ).replace(/\/$/, '');
+
+/** Lien « suivre ma commande » côté boutique (page order-tracking avec token signé). */
+export const buildOrderTrackingLink = (orderId: string, customerEmail?: string | null) => {
+  const base = shopBaseUrl();
+  if (!base) return null;
+  const token = generateOrderTrackingToken(orderId, customerEmail);
+  return `${base}/order-tracking/${orderId}?token=${token}`;
+};
+
 const getTrackingSecret = () => {
   const secret = process.env.ORDER_TRACKING_SECRET;
   if (!secret) {

--- a/server/src/validators/pickupPoint.ts
+++ b/server/src/validators/pickupPoint.ts
@@ -1,0 +1,69 @@
+export type PickupPointInput = {
+  code: string;
+  name: string;
+  network?: string;
+  line1?: string;
+  postalCode: string;
+  city: string;
+  country: string;
+};
+
+type PickupPointValidation =
+  | { ok: true; pickupPoint: PickupPointInput }
+  | { ok: false; error: string };
+
+const readString = (value: unknown, maxLength: number): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim().replace(/\s+/g, ' ');
+  return trimmed ? trimmed.slice(0, maxLength) : undefined;
+};
+
+/**
+ * Valide et normalise le point relais envoyé par le frontend au checkout.
+ * Validation de format uniquement : le code est revérifié par Boxtal au
+ * moment de la création de l'expédition (une valeur forgée fait échouer
+ * l'étiquette, pas le paiement).
+ */
+export function normalizePickupPointInput(input: unknown): PickupPointValidation {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { ok: false, error: 'Point relais invalide.' };
+  }
+
+  const value = input as Record<string, unknown>;
+  const address =
+    value.address && typeof value.address === 'object' && !Array.isArray(value.address)
+      ? (value.address as Record<string, unknown>)
+      : {};
+
+  const code = readString(value.code, 100);
+  const name = readString(value.name, 200);
+  const network = readString(value.network, 80);
+  const line1 = readString(address.line1 ?? address.street, 250);
+  const postalCode = readString(address.postalCode ?? address.zipCode, 30);
+  const city = readString(address.city, 100);
+  const country = (readString(address.country, 10) || 'FR').toUpperCase();
+
+  if (!code || !/^[A-Za-z0-9_.:-]{2,100}$/.test(code)) {
+    return { ok: false, error: 'Code du point relais invalide.' };
+  }
+  if (!name) {
+    return { ok: false, error: 'Nom du point relais requis.' };
+  }
+  if (!postalCode || !/^[A-Za-z0-9 -]{2,30}$/.test(postalCode)) {
+    return { ok: false, error: 'Code postal du point relais requis.' };
+  }
+  if (!city) {
+    return { ok: false, error: 'Ville du point relais requise.' };
+  }
+  if (!/^[A-Z]{2}$/.test(country)) {
+    return { ok: false, error: 'Pays du point relais invalide.' };
+  }
+  if (network && !/^[A-Za-z0-9_.:-]{2,80}$/.test(network)) {
+    return { ok: false, error: 'Réseau du point relais invalide.' };
+  }
+
+  return {
+    ok: true,
+    pickupPoint: { code, name, network, line1, postalCode, city, country },
+  };
+}


### PR DESCRIPTION
Intègre la livraison Boxtal (API v3) : points relais, génération d'étiquettes depuis l'admin, et suivi de colis automatisé par webhook.

## Ce que ça apporte

**Points relais** — `GET /api/shipping/parcel-points` proxifie la recherche Boxtal côté serveur (rate-limité 20 req/min/IP) : les clés API ne sortent jamais du back. Côté panier, `ParcelPointSelector` déclenche la recherche automatiquement dès que le code postal de livraison est saisi, et bloque la validation tant qu'aucun relais n'est choisi.

**Checkout** — le point relais est normalisé et validé côté serveur, puis transporté via les métadonnées Stripe jusqu'à la création de commande.

**Étiquettes** — `POST /api/admin/orders/:orderId/boxtal-shipment` crée l'expédition et persiste l'id Boxtal *immédiatement*, ce qui évite toute double étiquette même si la récupération du suivi échoue ensuite. Le même endpoint sert à resynchroniser une commande déjà expédiée.

**Suivi** — `POST /api/shipping/boxtal/webhook`, authentifié par HMAC-SHA256 sur le corps brut (comparaison timing-safe, hex ou base64, l'encodage n'étant pas documenté par Boxtal). Les transitions passent par un service `fulfillment` partagé et idempotent qui déclenche les emails d'expédition et de livraison.

**Client** — nouveau statut `PREPARING` exposé dans une timeline de commande partagée entre les pages commandes, détail et suivi.

## Schéma

`Order` gagne 4 colonnes nullables : `boxtalShippingOrderId` (unique), `labelUrl`, `pickupPointCode`, `pickupPoint`. Migration SQL écrite à la main (`migrate dev` veut reset la base de dev sur ce projet).

## Activation

Piloté par `BOXTAL_ACCESS_KEY` / `BOXTAL_SECRET_KEY`. Sans elles, tout se désactive proprement en 503 `BOXTAL_NOT_CONFIGURED` — la PR est donc sans effet tant que le `.env` de prod n'est pas renseigné. `validateEnv` vérifie que les deux clés sont présentes ou absentes ensemble.

## Tests

36 tests dédiés (config, normalisation, signature HMAC dans ses 4 cas, routes, webhook, endpoint admin) plus 2 cas de checkout. **Suite complète au vert : 416 tests, 26 fichiers.** Build front OK.

## À savoir avant de déployer

- La **souscription webhook chez Boxtal se fait à la main** (elle n'est pas programmatique), et le secret généré doit être recopié dans `BOXTAL_WEBHOOK_SECRET`. Sans cette étape, aucun suivi ne remonte et rien ne le signale.
- `BOXTAL_API_BASE_URL` pointe l'environnement de **test** par défaut.
- Le poids est estimé (`150 g + 50 g par article`), aucun poids réel n'existe en base.
- Deux comportements à corriger rapidement, documentés avec le reste de la dette dans `docs/PASSATION.md` : si le client n'a pas de téléphone c'est celui de la boutique qui part comme contact destinataire, et un nom de famille manquant est remplacé par « BoulevardTCG » sur l'étiquette.

## Aussi dans cette PR

`docs/PASSATION.md`, document de reprise (état du projet, pièges d'environnement, dette connue classée par risque, état des PRs ouvertes), plus la documentation technique du projet. `.claude/` et `_bmad/` passent dans `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
